### PR TITLE
Add ingest processor for rewrite and modify NeuralSparseQueryBuilder

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import org.opensearch.neuralsearch.processor.RewriteTokenProcessor;
 import org.opensearch.transport.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
@@ -133,7 +134,9 @@ public class NeuralSearch extends Plugin implements ActionPlugin, SearchPlugin, 
             TextImageEmbeddingProcessor.TYPE,
             new TextImageEmbeddingProcessorFactory(clientAccessor, parameters.env, parameters.ingestService.getClusterService()),
             TextChunkingProcessor.TYPE,
-            new TextChunkingProcessorFactory(parameters.env, parameters.ingestService.getClusterService(), parameters.analysisRegistry)
+            new TextChunkingProcessorFactory(parameters.env, parameters.ingestService.getClusterService(), parameters.analysisRegistry),
+            RewriteTokenProcessor.TYPE,
+            new RewriteTokenProcessor.Factory()
         );
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/RewriteTokenProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/RewriteTokenProcessor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor;
+
+import org.opensearch.ingest.AbstractProcessor;
+import org.opensearch.ingest.IngestDocument;
+import org.opensearch.ingest.Processor;
+import org.opensearch.neuralsearch.processor.util.ClusterUtils;
+
+import java.util.Map;
+
+import static org.opensearch.ingest.ConfigurationUtils.readStringProperty;
+
+/**
+ * Processor for rewriting token field to new token field
+ */
+public class RewriteTokenProcessor extends AbstractProcessor {
+    public static final String TYPE = "rewrite_token";
+    public static final String TOKEN_FIELD_KEY = "token_field";
+    public static final String CLUSTER_ID = "cluster_id";
+    private String tokenField;
+
+    protected RewriteTokenProcessor(String tag, String description, String tokenField) {
+        super(tag, description);
+        this.tokenField = tokenField;
+    }
+
+    @Override
+    public IngestDocument execute(IngestDocument ingestDocument) throws Exception {
+        Map<String, Float> tokens = ingestDocument.getFieldValue(tokenField, Map.class);
+        String clusterId = ingestDocument.getFieldValue(CLUSTER_ID, String.class);
+        Map<String, Float> newTokens = tokens.entrySet()
+            .stream()
+            .collect(java.util.stream.Collectors.toMap(e -> ClusterUtils.constructNewToken(e.getKey(), clusterId), Map.Entry::getValue));
+        ingestDocument.setFieldValue(tokenField, newTokens);
+        return ingestDocument;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    public static final class Factory implements Processor.Factory {
+
+        @Override
+        public Processor create(
+            Map<String, Processor.Factory> processorFactories,
+            String tag,
+            String description,
+            Map<String, Object> config
+        ) throws Exception {
+            String tokenField = readStringProperty(TYPE, tag, config, TOKEN_FIELD_KEY);
+            return new RewriteTokenProcessor(tag, description, tokenField);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/processor/util/ClusterUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/util/ClusterUtils.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor.util;
+
+/**
+ * Utility class for cluster related operations
+ */
+public class ClusterUtils {
+    public static String constructNewToken(String token, String clusterId) {
+        return token + "_" + clusterId;
+    }
+}


### PR DESCRIPTION
### Description
1. Add a new ingest processor to append cluster id to sparse tokens, if a sparse_encoding processor is used, this should be put after it.
2. Add logic in NeuralSparseQueryBuilder to rewrite tokens with cluster ids

create index
```
PUT {{index}}
{
  "mappings": {
    "properties": {
      "passage_text": {
        "type": "text"
      },
      "passage_embedding":{
          "type": "rank_features"
      }
    }
  }
}
```

ingest process example:
```
PUT _ingest/pipeline/ingest-pipeline
{
  "description": "This pipeline processes sparse tokens",
  "processors": [
    {
      "rewrite_token": {
        "token_field": "passage_embedding"
      },
      "remove": {
          "field": "cluster_id"
      }
    }
  ]
}
```

Bulk example:
```
POST _bulk?pipeline=ingest-pipeline
{ "index": { "_index": "{{index}}", "_id": "1" } }
{ "passage_text": "hello world", "passage_embedding": {"hello": 1.5, "world": 2.5}, "cluster_id": "cluster_1" }
{ "index": { "_index": "{{index}}", "_id": "2" } }
{ "passage_text": "apple banana", "passage_embedding": {"apple": 0.5, "banana": 1.3}, "cluster_id": "cluster_2"}
{ "index": { "_index": "{{index}}", "_id": "3" } }
{ "passage_text": "apple tree", "passage_embedding": {"apple": 3.5, "tree": 1.6}, "cluster_id": "cluster_3"}
```

Query example:
```
GET {{index}}/_search
{
    "query": {
        "neural_sparse": {
            "passage_embedding": {
                "query_tokens": {
                    "apple": 0.1,
                    "tree": 1.0
                },
                "search_cluster": true,
                "document_ratio": 0.1
            }
        }
    }
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
