### PR TITLE
Change strategry from making cluster token suffix to use cluster attribute

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.opensearch.neuralsearch.processor.RewriteTokenProcessor;
+import org.opensearch.neuralsearch.processor.util.DocumentClusterManager;
+import org.opensearch.neuralsearch.processor.util.JLTransformer;
 import org.opensearch.transport.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
@@ -106,6 +108,11 @@ public class NeuralSearch extends Plugin implements ActionPlugin, SearchPlugin, 
         NeuralSparseQueryBuilder.initialize(clientAccessor);
         HybridQueryExecutor.initialize(threadPool);
         normalizationProcessorWorkflow = new NormalizationProcessorWorkflow(new ScoreNormalizer(), new ScoreCombiner());
+
+        // Cluster initialization
+        DocumentClusterManager.getInstance().initialize();
+        JLTransformer.getInstance().initialize();
+
         return List.of(clientAccessor);
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/RewriteTokenProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/RewriteTokenProcessor.java
@@ -7,7 +7,7 @@ package org.opensearch.neuralsearch.processor;
 import org.opensearch.ingest.AbstractProcessor;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.Processor;
-import org.opensearch.neuralsearch.processor.util.ClusterUtils;
+import org.opensearch.neuralsearch.processor.util.DocumentClusterUtils;
 
 import java.util.Map;
 
@@ -33,7 +33,9 @@ public class RewriteTokenProcessor extends AbstractProcessor {
         String clusterId = ingestDocument.getFieldValue(CLUSTER_ID, String.class);
         Map<String, Float> newTokens = tokens.entrySet()
             .stream()
-            .collect(java.util.stream.Collectors.toMap(e -> ClusterUtils.constructNewToken(e.getKey(), clusterId), Map.Entry::getValue));
+            .collect(
+                java.util.stream.Collectors.toMap(e -> DocumentClusterUtils.constructNewToken(e.getKey(), clusterId), Map.Entry::getValue)
+            );
         ingestDocument.setFieldValue(tokenField, newTokens);
         return ingestDocument;
     }

--- a/src/main/java/org/opensearch/neuralsearch/processor/util/DocumentClusterManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/util/DocumentClusterManager.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor.util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
+
+import static org.apache.lucene.util.VectorUtil.dotProduct;
+
+/**
+ * Helper class with cluster representatives and assignments. Often used to getTopClusters from a query sketch.
+ */
+public class DocumentClusterManager {
+
+    private int totalDocCounts; // total number of documents within the index
+    private int[] clusterDocCounts; // number of documents across each cluster
+    private float[][] clusterRepresentatives; // an array of sketch vectors indicating the center of each cluster
+
+    // Resource paths relative to classpath
+    public static final int SKETCH_SIZE = 1024;
+    public static final int CLUSTER_NUM = 11896;
+    private static final String CLUSTER_ASSIGNMENT_RESOURCE = "assignment.bin";
+    private static final String CLUSTER_REPRESENTATIVE_RESOURCE = "representatives.bin";
+
+    // Instance is created at class loading time
+    private static final DocumentClusterManager INSTANCE = new DocumentClusterManager();
+
+    private DocumentClusterManager() {
+        // Private constructor due to singleton
+        initialize();
+    }
+
+    private void initialize() {
+        loadClusterAssignment();
+        loadClusterRepresentative();
+    }
+
+    public static DocumentClusterManager getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Loads cluster assignment data from a file in the temporary directory
+     */
+    private void loadClusterAssignment() {
+        try {
+            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+                String tempDir = System.getProperty("java.io.tmpdir");
+                File file = new File(tempDir, CLUSTER_ASSIGNMENT_RESOURCE);
+
+                if (!file.exists() || !file.canRead()) {
+                    System.err.println("Cluster assignment file doesn't exist or isn't readable: {}" + file.getAbsolutePath());
+                    return null;
+                }
+
+                try (FileInputStream fis = new FileInputStream(file)) {
+                    byte[] assignmentBytes = fis.readAllBytes();
+                    ByteBuffer assignmentBuffer = ByteBuffer.wrap(assignmentBytes).order(ByteOrder.nativeOrder());
+
+                    totalDocCounts = assignmentBytes.length / 4;
+                    clusterDocCounts = new int[CLUSTER_NUM];
+
+                    for (int i = 0; i < totalDocCounts; i++) {
+                        int clusterId = assignmentBuffer.getInt(i * 4);
+                        clusterDocCounts[clusterId] += 1;
+                    }
+
+                    System.out.println(
+                        "Successfully loaded cluster assignment data: {} clusters with {} total documents"
+                            + clusterDocCounts.length
+                            + " "
+                            + totalDocCounts
+                    );
+                } catch (IOException e) {
+                    System.err.println("Error reading cluster assignment file: " + e.getMessage());
+                }
+                return null;
+            });
+        } catch (PrivilegedActionException e) {
+            System.err.println("Security error while loading cluster assignment data: " + e.getException());
+        }
+    }
+
+    /**
+     * Loads cluster representative data from a file in the temporary directory
+     *
+     */
+    public void loadClusterRepresentative() {
+        try {
+            // Use AccessController to perform privileged file operations
+            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+                String tempDir = System.getProperty("java.io.tmpdir");
+                File file = new File(tempDir, CLUSTER_REPRESENTATIVE_RESOURCE);
+
+                if (!file.exists() || !file.canRead()) {
+                    System.err.println("Cluster assignment file doesn't exist or isn't readable: {}" + file.getAbsolutePath());
+                    return null;
+                }
+
+                try (FileInputStream fis = new FileInputStream(file)) {
+                    byte[] representativeBytes = fis.readAllBytes();
+                    ByteBuffer representativeBuffer = ByteBuffer.wrap(representativeBytes).order(ByteOrder.nativeOrder());
+
+                    // Verify file size matches expected dimensions
+                    if (representativeBytes.length != CLUSTER_NUM * SKETCH_SIZE * 4) {
+                        System.err.println("Warning: File size doesn't match expected dimensions!");
+                        System.err.println("Expected: " + (CLUSTER_NUM * SKETCH_SIZE * 4) + " bytes");
+                        System.err.println("Actual: " + representativeBytes.length + " bytes");
+                    }
+
+                    clusterRepresentatives = new float[CLUSTER_NUM][SKETCH_SIZE];
+                    for (int i = 0; i < CLUSTER_NUM; i++) {
+                        for (int j = 0; j < SKETCH_SIZE; j++) {
+                            clusterRepresentatives[i][j] = representativeBuffer.getFloat((i * SKETCH_SIZE + j) * 4);
+                        }
+                    }
+
+                    System.out.println(
+                        "Successfully loaded cluster assignment data: {} clusters with {} total documents"
+                            + clusterDocCounts.length
+                            + " "
+                            + totalDocCounts
+                    );
+                } catch (IOException e) {
+                    System.err.println("Error reading cluster assignment file: " + e.getMessage());
+                }
+                return null;
+            });
+        } catch (PrivilegedActionException e) {
+            System.err.println("Error loading cluster representative data: " + e.getMessage());
+            clusterRepresentatives = new float[0][0];
+        } catch (OutOfMemoryError e) {
+            System.err.println("Not enough memory to load cluster representative data: " + e.getMessage());
+            clusterRepresentatives = new float[0][0];
+        }
+    }
+
+    private float[] computeDotProductWithClusterRepresentatives(float[] querySketch) {
+        float[] dotProductWithClusterRepresentatives = new float[clusterRepresentatives.length];
+        for (int i = 0; i < clusterRepresentatives.length; i += 1) {
+            dotProductWithClusterRepresentatives[i] = dotProduct(querySketch, clusterRepresentatives[i]);
+        }
+        return dotProductWithClusterRepresentatives;
+    }
+
+    public Integer[] getTopClusters(float[] querySketch, float ratio) throws IllegalArgumentException {
+        if (ratio > 1 || ratio <= 0) {
+            throw new IllegalArgumentException("ratio should be in (0, 1]");
+        }
+        float[] dotProductWithClusterRepresentatives = computeDotProductWithClusterRepresentatives(querySketch);
+
+        Integer[] indices = new Integer[dotProductWithClusterRepresentatives.length];
+        for (int i = 0; i < dotProductWithClusterRepresentatives.length; i++) {
+            indices[i] = i;
+        }
+
+        // Sort indices by dot product values in descending order
+        Arrays.sort(indices, (a, b) -> Float.compare(dotProductWithClusterRepresentatives[b], dotProductWithClusterRepresentatives[a]));
+
+        // Calculate how many documents we need to cover based on the ratio
+        int documentsToExamine = (int) Math.ceil(ratio * totalDocCounts);
+
+        // Add clusters until we've covered enough documents
+        int totalDocsExamined = 0;
+        int numClustersNeeded = 0;
+
+        while (totalDocsExamined < documentsToExamine && numClustersNeeded < dotProductWithClusterRepresentatives.length) {
+            int clusterIndex = indices[numClustersNeeded];
+            totalDocsExamined += clusterDocCounts[clusterIndex];
+            numClustersNeeded++;
+        }
+
+        // Return result array with the top cluster IDs
+        return Arrays.copyOfRange(indices, 0, numClustersNeeded);
+    }
+
+    public int getTopCluster(float[] querySketch) {
+        float[] dotProductWithClusterRepresentatives = computeDotProductWithClusterRepresentatives(querySketch);
+        // Find the index of the maximum dot product
+        int maxIndex = 0;
+        float maxDotProduct = dotProductWithClusterRepresentatives[0];
+
+        for (int i = 1; i < dotProductWithClusterRepresentatives.length; i++) {
+            if (dotProductWithClusterRepresentatives[i] > maxDotProduct) {
+                maxDotProduct = dotProductWithClusterRepresentatives[i];
+                maxIndex = i;
+            }
+        }
+
+        return maxIndex;
+    }
+
+    public void addDoc(float[] querySketch) {
+        totalDocCounts += 1;
+        clusterDocCounts[getTopCluster(querySketch)] += 1;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/processor/util/DocumentClusterManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/util/DocumentClusterManager.java
@@ -28,8 +28,11 @@ public class DocumentClusterManager {
     // Resource paths relative to classpath
     public static final int SKETCH_SIZE = 1024;
     public static final int CLUSTER_NUM = 11896;
-    private static final String CLUSTER_ASSIGNMENT_RESOURCE = "assignment.bin";
-    private static final String CLUSTER_REPRESENTATIVE_RESOURCE = "representatives.bin";
+
+    private static final String SINNAMON_CLUSTER_ASSIGNMENT_RESOURCE = "sinnamon_assignment.bin";
+    private static final String SINNAMON_CLUSTER_REPRESENTATIVE_RESOURCE = "sinnamon_representative.bin";
+    private static final String JL_CLUSTER_ASSIGNMENT_RESOURCE = "jl_assignment.bin";
+    private static final String JL_CLUSTER_REPRESENTATIVE_RESOURCE = "jl_representative.bin";
 
     // Instance is created at class loading time
     private static final DocumentClusterManager INSTANCE = new DocumentClusterManager();
@@ -40,8 +43,8 @@ public class DocumentClusterManager {
     }
 
     private void initialize() {
-        loadClusterAssignment();
-        loadClusterRepresentative();
+        loadClusterAssignment(JL_CLUSTER_ASSIGNMENT_RESOURCE);
+        loadClusterRepresentative(JL_CLUSTER_REPRESENTATIVE_RESOURCE);
     }
 
     public static DocumentClusterManager getInstance() {
@@ -51,11 +54,11 @@ public class DocumentClusterManager {
     /**
      * Loads cluster assignment data from a file in the temporary directory
      */
-    private void loadClusterAssignment() {
+    private void loadClusterAssignment(String assignmentResourcePath) {
         try {
             AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
                 String tempDir = System.getProperty("java.io.tmpdir");
-                File file = new File(tempDir, CLUSTER_ASSIGNMENT_RESOURCE);
+                File file = new File(tempDir, assignmentResourcePath);
 
                 if (!file.exists() || !file.canRead()) {
                     System.err.println("Cluster assignment file doesn't exist or isn't readable: {}" + file.getAbsolutePath());
@@ -94,12 +97,12 @@ public class DocumentClusterManager {
      * Loads cluster representative data from a file in the temporary directory
      *
      */
-    public void loadClusterRepresentative() {
+    public void loadClusterRepresentative(String representativeResourcePath) {
         try {
             // Use AccessController to perform privileged file operations
             AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
                 String tempDir = System.getProperty("java.io.tmpdir");
-                File file = new File(tempDir, CLUSTER_REPRESENTATIVE_RESOURCE);
+                File file = new File(tempDir, representativeResourcePath);
 
                 if (!file.exists() || !file.canRead()) {
                     System.err.println("Cluster assignment file doesn't exist or isn't readable: {}" + file.getAbsolutePath());

--- a/src/main/java/org/opensearch/neuralsearch/processor/util/DocumentClusterUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/util/DocumentClusterUtils.java
@@ -7,7 +7,8 @@ package org.opensearch.neuralsearch.processor.util;
 /**
  * Utility class for cluster related operations
  */
-public class ClusterUtils {
+public class DocumentClusterUtils {
+
     public static String constructNewToken(String token, String clusterId) {
         return token + "_" + clusterId;
     }

--- a/src/main/java/org/opensearch/neuralsearch/processor/util/DocumentClusterUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/util/DocumentClusterUtils.java
@@ -4,6 +4,9 @@
  */
 package org.opensearch.neuralsearch.processor.util;
 
+import java.util.Map;
+import java.util.function.Function;
+
 /**
  * Utility class for cluster related operations
  */
@@ -11,5 +14,18 @@ public class DocumentClusterUtils {
 
     public static String constructNewToken(String token, String clusterId) {
         return token + "_" + clusterId;
+    }
+
+    public static String getClusterIdFromIndex(int clusterIdx) {
+        return String.valueOf(clusterIdx);
+    }
+
+    public static float[] sparseToDense(Map<String, Float> tokens, int denseDimension, Function<float[], float[]> convert) {
+        float[] query = new float[denseDimension];
+        for (Map.Entry<String, Float> entry : tokens.entrySet()) {
+            double value = ((Number) entry.getValue()).doubleValue();
+            query[Integer.parseInt(entry.getKey())] = (float) value;
+        }
+        return convert.apply(query);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/util/JLTransformer.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/util/JLTransformer.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor.util;
+
+public class JLTransformer {}

--- a/src/main/java/org/opensearch/neuralsearch/processor/util/JLTransformer.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/util/JLTransformer.java
@@ -4,4 +4,102 @@
  */
 package org.opensearch.neuralsearch.processor.util;
 
-public class JLTransformer {}
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+
+import static org.apache.lucene.util.VectorUtil.dotProduct;
+
+public class JLTransformer {
+    private float[][] projectionMatrix;
+
+    private static final String PROJECTION_MATRIX_RESOURCE = "jl_transformer.bin"; // default transformer path
+    private static final int INPUT_DIMENSION = 30109; // Input dimension
+    private static final int OUTPUT_DIMENSION = 1024;  // Output dimension
+
+    // Instance is created at class loading time
+    private static final JLTransformer INSTANCE = new JLTransformer();
+
+    public JLTransformer() {
+        initialize();
+    }
+
+    public static JLTransformer getInstance() {
+        return INSTANCE;
+    }
+
+    private void initialize() {
+        loadProjectionMatrix();
+    }
+
+    private void loadProjectionMatrix() {
+        try {
+            // Use AccessController to perform privileged file operations
+            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+                String tempDir = System.getProperty("java.io.tmpdir");
+                File file = new File(tempDir, PROJECTION_MATRIX_RESOURCE);
+
+                if (!file.exists() || !file.canRead()) {
+                    System.err.println("Projection matrix file doesn't exist or isn't readable: " + file.getAbsolutePath());
+                    projectionMatrix = new float[0][0];
+                    return null;
+                }
+
+                try (FileInputStream fis = new FileInputStream(file)) {
+                    byte[] matrixBytes = fis.readAllBytes();
+                    ByteBuffer matrixBuffer = ByteBuffer.wrap(matrixBytes).order(ByteOrder.nativeOrder());
+
+                    // Verify the size of file
+                    int expectedSize = OUTPUT_DIMENSION * INPUT_DIMENSION * 4; // 4 bytes per float
+                    if (matrixBytes.length != expectedSize) {
+                        System.err.println("Warning: File size doesn't match expected dimensions!");
+                        System.err.println("Expected: " + expectedSize + " bytes");
+                        System.err.println("Actual: " + matrixBytes.length + " bytes");
+                    }
+
+                    // Initialize the projection matrix
+                    projectionMatrix = new float[OUTPUT_DIMENSION][INPUT_DIMENSION];
+
+                    // Read matrix data
+                    for (int i = 0; i < OUTPUT_DIMENSION; i++) {
+                        for (int j = 0; j < INPUT_DIMENSION; j++) {
+                            projectionMatrix[i][j] = matrixBuffer.getFloat((i * INPUT_DIMENSION + j) * 4);
+                        }
+                    }
+
+                    System.out.println("Successfully loaded projection matrix: " + OUTPUT_DIMENSION + " x " + INPUT_DIMENSION);
+                } catch (IOException e) {
+                    System.err.println("Error reading projection matrix file: " + e.getMessage());
+                    projectionMatrix = new float[0][0];
+                }
+                return null;
+            });
+        } catch (PrivilegedActionException e) {
+            System.err.println("Error jl transformer data: " + e.getMessage());
+            projectionMatrix = new float[0][0];
+        } catch (OutOfMemoryError e) {
+            System.err.println("Not enough memory to load projection matrix: " + e.getMessage());
+            projectionMatrix = new float[0][0];
+        }
+    }
+
+    public float[] convertSketchVector(float[] vector) {
+        if (projectionMatrix.length == 0 || vector.length != INPUT_DIMENSION) {
+            throw new IllegalArgumentException("Invalid dimensions for projection");
+        }
+
+        float[] result = new float[OUTPUT_DIMENSION];
+
+        for (int i = 0; i < projectionMatrix.length; i++) {
+            // Each row of the matrix is multiplied with the vector (dot product)
+            result[i] = dotProduct(projectionMatrix[i], vector);
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/processor/util/JLTransformer.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/util/JLTransformer.java
@@ -23,17 +23,22 @@ public class JLTransformer {
     private static final int OUTPUT_DIMENSION = 1024;  // Output dimension
 
     // Instance is created at class loading time
-    private static final JLTransformer INSTANCE = new JLTransformer();
+    private static volatile JLTransformer INSTANCE;
 
-    public JLTransformer() {
-        initialize();
-    }
+    private JLTransformer() {}
 
     public static JLTransformer getInstance() {
+        if (INSTANCE == null) {
+            synchronized (JLTransformer.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = new JLTransformer();
+                }
+            }
+        }
         return INSTANCE;
     }
 
-    private void initialize() {
+    public void initialize() {
         loadProjectionMatrix();
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/util/SinnamonTransformer.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/util/SinnamonTransformer.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor.util;
+
+public class SinnamonTransformer {}

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
@@ -56,8 +56,7 @@ import lombok.experimental.Accessors;
 import org.opensearch.neuralsearch.util.prune.PruneType;
 import org.opensearch.neuralsearch.util.prune.PruneUtils;
 
-import static java.lang.Math.max;
-import static org.opensearch.neuralsearch.processor.util.DocumentClusterManager.SKETCH_SIZE;
+import org.opensearch.neuralsearch.processor.util.JLTransformer;
 
 /**
  * SparseEncodingQueryBuilder is responsible for handling "neural_sparse" query types. It uses an ML NEURAL_SPARSE model
@@ -349,13 +348,9 @@ public class NeuralSparseQueryBuilder extends AbstractQueryBuilder<NeuralSparseQ
             query[Integer.parseInt(entry.getKey())] = entry.getValue();
         }
         // step 2: transform query tokens to sketch
-        float[] querySketch = new float[SKETCH_SIZE];
-        for (int i = 0; i < query.length; i++) {
-            querySketch[i % SKETCH_SIZE] = max(querySketch[i % SKETCH_SIZE], query[i]);
-        }
+        float[] querySketch = JLTransformer.getInstance().convertSketchVector(query);
         // step 3: call cluster service to get top clusters with ratio
         Integer[] topClusters = DocumentClusterManager.getInstance().getTopClusters(querySketch, this.documentRatio);
-
         return Arrays.stream(topClusters).map(id -> "cluster_" + id).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
### Description
1. Make "sketch_type" a ingest processor field, not a document attribute to save storage.
2. Change strategry from making cluster token suffix to use cluster attribute

Create index with index sorting
```
PUT /{{index}}
{
    "settings": {
    "index": {
      "sort.field": "cluster_id", 
      "sort.order": "asc"  
    }
  },
  "mappings": {
    "properties": {
      "passage_text": {
        "type": "text"
      },
      "passage_embedding":{
          "type": "rank_features"
      },
      "cluster_id": {
          "type": "long"
      }
    }
  }
}
```

create ingest processor
```
PUT /_ingest/pipeline/{{ingest-pipeline}}
{
  "description": "This pipeline processes student data",
  "processors": [
    {
      "rewrite_token": {
        "token_field": "passage_embedding",
        "sketch_type": "jlt"
      }
    }
  ]
}
```
