### PR TITLE
Support keyword, range

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/processor/RewriteTokenProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/RewriteTokenProcessor.java
@@ -36,14 +36,15 @@ public class RewriteTokenProcessor extends AbstractProcessor {
     public IngestDocument execute(IngestDocument ingestDocument) throws Exception {
         Map<String, Float> tokens = ingestDocument.getFieldValue(tokenField, Map.class);
         Integer clusterId = null;
-        if (ingestDocument.hasField(CLUSTER_ID)) {
-            clusterId = ingestDocument.getFieldValue(CLUSTER_ID, Integer.class);
-        } else {
+        if (!ingestDocument.hasField(CLUSTER_ID)) {
             float[] sketch = DocumentClusterUtils.sparseToDense(tokens, 30109, this.sketchType);
             clusterId = DocumentClusterManager.getInstance().getTopCluster(sketch, this.sketchType);
+            if ("keyword".equals(DocumentClusterManager.getInstance().getClusterIdMethod())) {
+                ingestDocument.setFieldValue(CLUSTER_ID, String.valueOf(clusterId));
+            } else {
+                ingestDocument.setFieldValue(CLUSTER_ID, clusterId);
+            }
         }
-        ingestDocument.setFieldValue(CLUSTER_ID, clusterId);
-
         return ingestDocument;
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/util/DocumentClusterManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/util/DocumentClusterManager.java
@@ -4,6 +4,9 @@
  */
 package org.opensearch.neuralsearch.processor.util;
 
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -20,12 +23,16 @@ import static org.apache.lucene.util.VectorUtil.dotProduct;
 /**
  * Helper class with cluster representatives and assignments. Often used to getTopClusters from a query sketch.
  */
+@Log4j2
 public class DocumentClusterManager {
 
     private int totalDocCounts; // total number of documents within the index
     private int[] clusterDocCounts; // number of documents across each cluster, both jl and sinnamon share the same assignment
     private float[][] jlClusterRepresentatives; // an array of jl sketch vectors indicating the center of each cluster
     private float[][] sinnamonClusterRepresentatives; // an array of sinnamon sketch vectors indicating the center of each cluster
+
+    @Getter
+    private String clusterIdMethod;
 
     // Resource paths relative to classpath
     public static final int SKETCH_SIZE = 1024;
@@ -45,6 +52,8 @@ public class DocumentClusterManager {
         clusterDocCounts = loadClusterAssignment();
         jlClusterRepresentatives = loadClusterRepresentative(JL_CLUSTER_REPRESENTATIVE_RESOURCE);
         sinnamonClusterRepresentatives = loadClusterRepresentative(SINNAMON_CLUSTER_REPRESENTATIVE_RESOURCE);
+        clusterIdMethod = System.getProperty("ann.clusterid");
+        log.info("cluster id method: {}", clusterIdMethod);
     }
 
     // lazy load

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
@@ -425,7 +425,11 @@ public class NeuralSparseQueryBuilder extends AbstractQueryBuilder<NeuralSparseQ
                 Integer currentId = clusterIds.get(i);
                 if (currentId == lastId + step) {
                     ++step;
-                    continue;
+                    if (i == clusterIds.size() - 1) {
+                        ++i;
+                    } else {
+                        continue;
+                    }
                 }
                 step = 1;
                 subBoolean.add(IntPoint.newRangeQuery(FIELD_NAME, lastId, clusterIds.get(i - 1)), BooleanClause.Occur.SHOULD);

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
@@ -421,11 +421,12 @@ public class NeuralSparseQueryBuilder extends AbstractQueryBuilder<NeuralSparseQ
             subBoolean.setMinimumNumberShouldMatch(1);
             Integer lastId = clusterIds.get(0);
             int step = 1;
-            for (int i = 1; i < clusterIds.size(); i++) {
+            int clusterSize = clusterIds.size();
+            for (int i = 1; i < clusterSize; i++) {
                 Integer currentId = clusterIds.get(i);
                 if (currentId == lastId + step) {
                     ++step;
-                    if (i == clusterIds.size() - 1) {
+                    if (i == clusterSize - 1) {
                         ++i;
                     } else {
                         continue;

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
@@ -14,16 +14,19 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.lucene.document.FeatureField;
+import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.opensearch.Version;
 import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.index.query.TermsQueryBuilder;
 import org.opensearch.neuralsearch.processor.util.DocumentClusterManager;
 import org.opensearch.neuralsearch.processor.util.DocumentClusterUtils;
 import org.opensearch.transport.client.Client;
@@ -404,9 +407,37 @@ public class NeuralSparseQueryBuilder extends AbstractQueryBuilder<NeuralSparseQ
         ));
     }
 
-    private Query constructTermQueryWithClusterIds(QueryShardContext context, List<Integer> clusterIds) throws IOException {
-        Query query = NumberFieldMapper.NumberType.INTEGER.termsQuery("cluster_id", Collections.unmodifiableList(clusterIds), false, true);
-        return query;
+    private void constructTermQueryWithClusterIds(BooleanQuery.Builder builder, QueryShardContext context, List<Integer> clusterIds)
+        throws IOException {
+        final String FIELD_NAME = "cluster_id";
+        String clusterIdMethod = DocumentClusterManager.getInstance().getClusterIdMethod();
+        if (StringUtils.isEmpty(clusterIdMethod) || clusterIdMethod.equals("set")) {
+            builder.add(
+                NumberFieldMapper.NumberType.INTEGER.termsQuery(FIELD_NAME, Collections.unmodifiableList(clusterIds), false, true),
+                BooleanClause.Occur.FILTER
+            );
+        } else if (clusterIdMethod.equals("range")) {
+            BooleanQuery.Builder subBoolean = new BooleanQuery.Builder();
+            subBoolean.setMinimumNumberShouldMatch(1);
+            Integer lastId = clusterIds.get(0);
+            int step = 1;
+            for (int i = 1; i < clusterIds.size(); i++) {
+                Integer currentId = clusterIds.get(i);
+                if (currentId == lastId + step) {
+                    ++step;
+                    continue;
+                }
+                step = 1;
+                subBoolean.add(IntPoint.newRangeQuery(FIELD_NAME, lastId, clusterIds.get(i - 1)), BooleanClause.Occur.SHOULD);
+                lastId = currentId;
+            }
+            builder.add(subBoolean.build(), BooleanClause.Occur.FILTER);
+        } else if (clusterIdMethod.equals("keyword")) {
+            builder.add(
+                new TermsQueryBuilder(FIELD_NAME, clusterIds.stream().map(String::valueOf).collect(Collectors.toList())).toQuery(context),
+                BooleanClause.Occur.FILTER
+            );
+        }
     }
 
     @Override
@@ -418,8 +449,7 @@ public class NeuralSparseQueryBuilder extends AbstractQueryBuilder<NeuralSparseQ
         if (this.searchCluster) {
             // generate term query for cluster ids
             final List<Integer> clusterIds = getClusterIds(queryTokens);
-            Query termQuery = constructTermQueryWithClusterIds(context, clusterIds);
-            builder.add(termQuery, BooleanClause.Occur.FILTER);
+            constructTermQueryWithClusterIds(builder, context, clusterIds);
             builder.setMinimumNumberShouldMatch(1);
         }
 


### PR DESCRIPTION
add jvm.options:
-Dann.clusterid=[set, range, keyword]

- set: integer cluster_id, query with PointsSetQuery, which we benchmarked already
- range: integer cluster_id, query with PointRangeQuery`
- keyword: keyword cluster_id, query with termsquery