### PR TITLE
Fix in-memory data are not cleared bug

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -16,6 +16,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import org.apache.lucene.util.Accountables;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexSettings;
@@ -31,6 +33,8 @@ import org.opensearch.neuralsearch.settings.NeuralSearchSettingsAccessor;
 import org.opensearch.neuralsearch.sparse.SparseIndexEventListener;
 import org.opensearch.neuralsearch.sparse.SparseSettings;
 import org.opensearch.neuralsearch.sparse.algorithm.ClusterTrainingRunning;
+import org.opensearch.neuralsearch.sparse.codec.InMemoryClusteredPosting;
+import org.opensearch.neuralsearch.sparse.codec.InMemorySparseVectorForwardIndex;
 import org.opensearch.neuralsearch.sparse.codec.SparseCodecService;
 import org.opensearch.neuralsearch.sparse.mapper.SparseTokensFieldMapper;
 import org.opensearch.neuralsearch.sparse.query.SparseAnnQueryBuilder;
@@ -281,7 +285,8 @@ public class NeuralSearch extends Plugin
             NEURAL_SEARCH_HYBRID_SEARCH_DISABLED,
             RERANKER_MAX_DOC_FIELDS,
             NEURAL_STATS_ENABLED,
-            SparseSettings.IS_SPARSE_INDEX_SETTING
+            SparseSettings.IS_SPARSE_INDEX_SETTING,
+            SparseSettings.SPARSE_MEMORY_SETTING
         );
     }
 
@@ -345,6 +350,15 @@ public class NeuralSearch extends Plugin
     public void onIndexModule(IndexModule indexModule) {
         if (SparseSettings.IS_SPARSE_INDEX_SETTING.get(indexModule.getSettings())) {
             indexModule.addIndexEventListener(new SparseIndexEventListener());
+            indexModule.addSettingsUpdateConsumer(SparseSettings.SPARSE_MEMORY_SETTING, (v) -> {
+                // just to log in-memory data usage
+                InMemoryClusteredPosting inMemoryClusteredPosting = new InMemoryClusteredPosting();
+                log.info(
+                    "memory usage: forward index {}, posting: {}",
+                    RamUsageEstimator.humanReadableUnits(InMemorySparseVectorForwardIndex.memUsage()),
+                    Accountables.toString(inMemoryClusteredPosting)
+                );
+            });
         }
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
@@ -8,8 +8,6 @@ import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentInfos;
-import org.apache.lucene.util.Accountables;
-import org.apache.lucene.util.RamUsageEstimator;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
@@ -39,12 +37,7 @@ public class SparseIndexEventListener implements IndexEventListener {
                         }
                     }
                 }
-                InMemoryClusteredPosting inMemoryClusteredPosting = new InMemoryClusteredPosting();
-                log.info(
-                    "memory usage after delete index: forward index {}, posting: {}",
-                    RamUsageEstimator.humanReadableUnits(InMemorySparseVectorForwardIndex.memUsage()),
-                    Accountables.toString(inMemoryClusteredPosting)
-                );
+
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
@@ -5,7 +5,6 @@
 package org.opensearch.neuralsearch.sparse;
 
 import lombok.AllArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentInfos;
 import org.opensearch.index.IndexService;
@@ -19,7 +18,6 @@ import org.opensearch.neuralsearch.sparse.codec.InMemorySparseVectorForwardIndex
 import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 import org.opensearch.neuralsearch.sparse.mapper.SparseTokensFieldType;
 
-@Log4j2
 @AllArgsConstructor
 public class SparseIndexEventListener implements IndexEventListener {
     public void beforeIndexRemoved(IndexService indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason reason) {
@@ -37,7 +35,6 @@ public class SparseIndexEventListener implements IndexEventListener {
                         }
                     }
                 }
-
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
@@ -5,8 +5,11 @@
 package org.opensearch.neuralsearch.sparse;
 
 import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.util.Accountables;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
@@ -18,6 +21,7 @@ import org.opensearch.neuralsearch.sparse.codec.InMemorySparseVectorForwardIndex
 import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 import org.opensearch.neuralsearch.sparse.mapper.SparseTokensFieldType;
 
+@Log4j2
 @AllArgsConstructor
 public class SparseIndexEventListener implements IndexEventListener {
     public void beforeIndexRemoved(IndexService indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason reason) {
@@ -35,6 +39,12 @@ public class SparseIndexEventListener implements IndexEventListener {
                         }
                     }
                 }
+                InMemoryClusteredPosting inMemoryClusteredPosting = new InMemoryClusteredPosting();
+                log.info(
+                    "memory usage after delete index: forward index {}, posting: {}",
+                    RamUsageEstimator.humanReadableUnits(InMemorySparseVectorForwardIndex.memUsage()),
+                    Accountables.toString(inMemoryClusteredPosting)
+                );
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/SparseSettings.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/SparseSettings.java
@@ -17,6 +17,7 @@ import static org.opensearch.common.settings.Setting.Property.IndexScope;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class SparseSettings {
     public static final String SPARSE_INDEX = "index.sparse";
+    public static final String MEMORY_USAGE = "index.sparse.memory";
 
     private static SparseSettings INSTANCE;
 
@@ -31,5 +32,14 @@ public class SparseSettings {
      * This setting identifies sparse index.
      */
     public static final Setting<Boolean> IS_SPARSE_INDEX_SETTING = Setting.boolSetting(SPARSE_INDEX, false, IndexScope, Final);
+    /**
+     * This is just a fake setting for POC whenever it changes value, we output the memory usage of the in-memory data
+     */
+    public static final Setting<Boolean> SPARSE_MEMORY_SETTING = Setting.boolSetting(
+        MEMORY_USAGE,
+        false,
+        IndexScope,
+        Setting.Property.Dynamic
+    );
 
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/DocumentCluster.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/DocumentCluster.java
@@ -7,12 +7,15 @@ package org.opensearch.neuralsearch.sparse.algorithm;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.opensearch.neuralsearch.sparse.common.DocFreq;
 import org.opensearch.neuralsearch.sparse.common.DocFreqIterator;
 import org.opensearch.neuralsearch.sparse.common.IteratorWrapper;
 import org.opensearch.neuralsearch.sparse.common.SparseVector;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -22,7 +25,7 @@ import java.util.List;
 @Getter
 @Setter
 @EqualsAndHashCode
-public class DocumentCluster {
+public class DocumentCluster implements Accountable {
     private SparseVector summary;
     private final List<DocFreq> docs;
     // if true, docs in this cluster should always be examined
@@ -75,5 +78,21 @@ public class DocumentCluster {
                 return 0;
             }
         };
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return RamUsageEstimator.shallowSizeOfInstance(DocumentCluster.class) + docs.size() * RamUsageEstimator.shallowSizeOfInstance(
+            DocFreq.class
+        );
+    }
+
+    @Override
+    public Collection<Accountable> getChildResources() {
+        List<Accountable> children = new ArrayList<>();
+        if (summary != null) {
+            children.add(summary);
+        }
+        return Collections.unmodifiableList(children);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/KMeansPlusPlus.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/KMeansPlusPlus.java
@@ -53,7 +53,7 @@ public class KMeansPlusPlus implements Clustering {
             if (docVector == null) continue;
             for (int i = 0; i < num_cluster; i++) {
                 float score = Float.MIN_VALUE;
-                float [] center = denseCentroids.get(i);
+                float[] center = denseCentroids.get(i);
                 if (center != null) {
                     score = docVector.dotProduct(center);
                 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/PostingClusters.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/PostingClusters.java
@@ -5,6 +5,8 @@
 package org.opensearch.neuralsearch.sparse.algorithm;
 
 import lombok.Getter;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.opensearch.neuralsearch.sparse.common.IteratorWrapper;
 
 import java.util.List;
@@ -13,7 +15,7 @@ import java.util.List;
  * This class represents the clusters of postings for a field
  */
 @Getter
-public class PostingClusters {
+public class PostingClusters implements Accountable {
     private final List<DocumentCluster> clusters;
     private final int size;
 
@@ -32,5 +34,14 @@ public class PostingClusters {
 
     public IteratorWrapper<DocumentCluster> iterator() {
         return new IteratorWrapper<DocumentCluster>(this.clusters.iterator());
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        long ramUsed = RamUsageEstimator.shallowSizeOfInstance(PostingClusters.class);
+        for (DocumentCluster cluster : clusters) {
+            ramUsed += cluster.ramBytesUsed();
+        }
+        return ramUsed;
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriter.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriter.java
@@ -28,7 +28,8 @@ public class ClusteredPostingTermsWriter {
     public ClusteredPostingTermsWriter(SegmentWriteState state, FieldInfo fieldInfo) {
         super();
         InMemoryKey.IndexKey key = new InMemoryKey.IndexKey(state.segmentInfo, fieldInfo);
-        SparseVectorForwardIndex index = SparseVectorForwardIndex.getOrCreate(key);
+        SparseVectorForwardIndex index = InMemorySparseVectorForwardIndex.get(key);
+        assert (index != null);
         int beta = Integer.parseInt(fieldInfo.attributes().get(SparseMethodContext.BETA_FIELD));
         int lambda = Integer.parseInt(fieldInfo.attributes().get(SparseMethodContext.LAMBDA_FIELD));
         float alpha = Float.parseFloat(fieldInfo.attributes().get(SparseMethodContext.ALPHA_FIELD));

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesPassThrough.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesPassThrough.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.util.BytesRef;
+
+import java.io.IOException;
+
+@AllArgsConstructor
+public class SparseBinaryDocValuesPassThrough extends BinaryDocValues {
+    private final BinaryDocValues delegate;
+    @Getter
+    private final SegmentInfo segmentInfo;
+
+    @Override
+    public BytesRef binaryValue() throws IOException {
+        return this.delegate.binaryValue();
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+        return this.delegate.advanceExact(target);
+    }
+
+    @Override
+    public int docID() {
+        return this.delegate.docID();
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+        return this.delegate.nextDoc();
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+        return this.delegate.advance(target);
+    }
+
+    @Override
+    public long cost() {
+        return this.delegate.cost();
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
@@ -4,6 +4,7 @@
  */
 package org.opensearch.neuralsearch.sparse.codec;
 
+import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.DocValuesConsumer;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.index.BinaryDocValues;
@@ -13,14 +14,17 @@ import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.opensearch.neuralsearch.sparse.SparseTokensField;
 import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
+import org.opensearch.neuralsearch.sparse.common.MergeHelper;
 
 import java.io.IOException;
 
 /**
  * A DocValuesConsumer that writes sparse doc values to a segment.
  */
+@Log4j2
 public class SparseDocValuesConsumer extends DocValuesConsumer {
     private final DocValuesConsumer delegate;
     private final SegmentWriteState state;
@@ -52,14 +56,7 @@ public class SparseDocValuesConsumer extends DocValuesConsumer {
                 return;
             }
             SparseDocValuesReader reader = (SparseDocValuesReader) valuesProducer;
-            for (DocValuesProducer producer : reader.getMergeState().docValuesProducers) {
-                if (!(producer instanceof SparseDocValuesProducer)) {
-                    continue;
-                }
-                SparseDocValuesProducer sparseDocValuesProducer = (SparseDocValuesProducer) producer;
-                InMemoryKey.IndexKey key = new InMemoryKey.IndexKey(sparseDocValuesProducer.getState().segmentInfo, field);
-                SparseVectorForwardIndex.removeIndex(key);
-            }
+            MergeHelper.clearInMemoryData(reader.getMergeState(), field, SparseVectorForwardIndex::removeIndex);
         }
         BinaryDocValues binaryDocValues = valuesProducer.getBinary(field);
         int docId;
@@ -104,6 +101,10 @@ public class SparseDocValuesConsumer extends DocValuesConsumer {
                     addBinary(fieldInfo, new SparseDocValuesReader(mergeState), true);
                 }
             }
+            log.info(
+                "memory usage after binary doc value merge: {}",
+                RamUsageEstimator.humanReadableUnits(InMemorySparseVectorForwardIndex.memUsage())
+            );
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
@@ -14,7 +14,6 @@ import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.RamUsageEstimator;
 import org.opensearch.neuralsearch.sparse.SparseTokensField;
 import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 import org.opensearch.neuralsearch.sparse.common.MergeHelper;
@@ -101,10 +100,6 @@ public class SparseDocValuesConsumer extends DocValuesConsumer {
                     addBinary(fieldInfo, new SparseDocValuesReader(mergeState), true);
                 }
             }
-            log.info(
-                "memory usage after binary doc value merge: {}",
-                RamUsageEstimator.humanReadableUnits(InMemorySparseVectorForwardIndex.memUsage())
-            );
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesProducer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesProducer.java
@@ -38,7 +38,7 @@ public class SparseDocValuesProducer extends DocValuesProducer {
 
     @Override
     public BinaryDocValues getBinary(FieldInfo field) throws IOException {
-        return this.delegate.getBinary(field);
+        return new SparseBinaryDocValuesPassThrough(this.delegate.getBinary(field), this.getState().segmentInfo);
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumer.java
@@ -5,9 +5,7 @@
 package org.opensearch.neuralsearch.sparse.codec;
 
 import org.apache.lucene.codecs.FieldsConsumer;
-import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.NormsProducer;
-import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.MergeState;
@@ -16,7 +14,7 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.neuralsearch.sparse.SparseTokensField;
-import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
+import org.opensearch.neuralsearch.sparse.common.MergeHelper;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -85,21 +83,6 @@ public class SparsePostingsConsumer extends FieldsConsumer {
         }
     }
 
-    private void clearInMemoryPostings(MergeState mergeState) {
-        for (int readerIndex = 0; readerIndex < mergeState.fieldsProducers.length; readerIndex++) {
-            final FieldsProducer f = mergeState.fieldsProducers[readerIndex];
-            if (!(f instanceof SparsePostingsProducer)) {
-                continue;
-            }
-
-            SparsePostingsProducer producer = (SparsePostingsProducer) f;
-            for (FieldInfo fieldInfo : mergeState.mergeFieldInfos) {
-                InMemoryKey.IndexKey key = new InMemoryKey.IndexKey(producer.getState().segmentInfo, fieldInfo);
-                InMemoryClusteredPosting.clearIndex(key);
-            }
-        }
-    }
-
     @Override
     public void merge(MergeState mergeState, NormsProducer norms) throws IOException {
         // merge non-sparse fields
@@ -107,7 +90,7 @@ public class SparsePostingsConsumer extends FieldsConsumer {
         // merge sparse fields
         SparsePostingsReader sparsePostingsReader = new SparsePostingsReader(mergeState);
         sparsePostingsReader.merge();
-        clearInMemoryPostings(mergeState);
+        MergeHelper.clearInMemoryData(mergeState, null, InMemoryClusteredPosting::clearIndex);
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsReader.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsReader.java
@@ -12,7 +12,6 @@ import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
-import org.apache.lucene.util.Accountables;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.neuralsearch.sparse.SparseTokensField;
 import org.opensearch.neuralsearch.sparse.algorithm.ClusterTrainingRunning;
@@ -34,7 +33,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Merge sparse postings
@@ -42,7 +40,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Log4j2
 public class SparsePostingsReader {
     private final MergeState mergeState;
-    private static AtomicInteger counter = new AtomicInteger(0);
 
     public SparsePostingsReader(MergeState state) {
         this.mergeState = state;
@@ -127,10 +124,7 @@ public class SparsePostingsReader {
                 }
                 return null;
             }));
-            InMemoryClusteredPosting posting = new InMemoryClusteredPosting();
             for (Map.Entry<BytesRef, Set<DocFreq>> entry : docs.entrySet()) {
-                String term = entry.getKey().utf8ToString();
-                counter.addAndGet(1);
                 ClusterTrainingRunning.getInstance().run(new Runnable() {
                     @Override
                     public void run() {
@@ -141,14 +135,6 @@ public class SparsePostingsReader {
                             throw new RuntimeException(e);
                         }
                         InMemoryClusteredPosting.InMemoryClusteredPostingWriter.writePostingClusters(key, entry.getKey(), cluster);
-                        if (counter.addAndGet(-1) == 0) {
-                            log.info(
-                                "clustered postings memory usage for field {} term {} is: {}",
-                                fieldInfo.name,
-                                entry.getKey().utf8ToString(),
-                                Accountables.toString(posting)
-                            );
-                        }
                     }
                 });
             }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/common/MergeHelper.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/common/MergeHelper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.common;
+
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.MergeState;
+import org.opensearch.neuralsearch.sparse.SparseTokensField;
+import org.opensearch.neuralsearch.sparse.codec.SparseBinaryDocValuesPassThrough;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+
+public class MergeHelper {
+    public static void clearInMemoryData(MergeState mergeState, FieldInfo fieldInfo, Consumer<InMemoryKey.IndexKey> consumer)
+        throws IOException {
+        for (DocValuesProducer producer : mergeState.docValuesProducers) {
+            for (FieldInfo field : mergeState.mergeFieldInfos) {
+                if (!SparseTokensField.isSparseField(field) || (fieldInfo != null && field != fieldInfo)) {
+                    continue;
+                }
+                BinaryDocValues binaryDocValues = producer.getBinary(field);
+                if (!(binaryDocValues instanceof SparseBinaryDocValuesPassThrough)) {
+                    continue;
+                }
+                SparseBinaryDocValuesPassThrough binaryDocValuesPassThrough = (SparseBinaryDocValuesPassThrough) binaryDocValues;
+                InMemoryKey.IndexKey key = new InMemoryKey.IndexKey(binaryDocValuesPassThrough.getSegmentInfo(), field);
+                consumer.accept(key);
+            }
+        }
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/common/SparseVector.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/common/SparseVector.java
@@ -8,8 +8,10 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -24,7 +26,7 @@ import java.util.stream.Collectors;
  * Sparse vector implementation, which is a list of (token, freq) pairs
  */
 @EqualsAndHashCode
-public class SparseVector {
+public class SparseVector implements Accountable {
     private final int size;
     // tokens will be stored in order
     private int[] tokens;
@@ -175,6 +177,13 @@ public class SparseVector {
                 return new Item(tokens[current], freqs[current]);
             }
         });
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return RamUsageEstimator.shallowSizeOfInstance(SparseVector.class) + RamUsageEstimator.sizeOf(tokens) + RamUsageEstimator.sizeOf(
+            freqs
+        );
     }
 
     @AllArgsConstructor

--- a/src/main/java/org/opensearch/neuralsearch/sparse/query/PostingWithClustersScorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/query/PostingWithClustersScorer.java
@@ -91,10 +91,13 @@ public class PostingWithClustersScorer extends Scorer {
                     sparsePostingsEnum.getClusters().getClusters().size()
                 );
                 if (null == reader) {
-                    SparseVectorForwardIndex.SparseVectorForwardIndexReader indexReader = InMemorySparseVectorForwardIndex.getOrCreate(
-                        sparsePostingsEnum.getIndexKey()
-                    ).getForwardIndexReader();
-                    reader = (docId) -> { return indexReader.readSparseVector(docId); };
+                    SparseVectorForwardIndex index = InMemorySparseVectorForwardIndex.get(sparsePostingsEnum.getIndexKey());
+                    if (index != null) {
+                        SparseVectorForwardIndex.SparseVectorForwardIndexReader indexReader = index.getForwardIndexReader();
+                        reader = (docId) -> { return indexReader.readSparseVector(docId); };
+                    } else {
+                        reader = (docId) -> { return null; };
+                    }
                 }
                 subScorers.add(new SingleScorer(sparsePostingsEnum, term));
             }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/query/SparseQueryWeight.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/query/SparseQueryWeight.java
@@ -66,9 +66,8 @@ public class SparseQueryWeight extends Weight {
         if (info != null) {
             log.info("segment info: {}", info.name);
             InMemoryKey.IndexKey key = new InMemoryKey.IndexKey(info, fieldType);
-            SparseVectorForwardIndex.SparseVectorForwardIndexReader reader = InMemorySparseVectorForwardIndex.getOrCreate(key)
-                .getForwardIndexReader();
-            sparseReader = reader::readSparseVector;
+            SparseVectorForwardIndex index = InMemorySparseVectorForwardIndex.get(key);
+            sparseReader = index != null ? index.getForwardIndexReader()::readSparseVector : (docId -> { return null; });
         }
         final Scorer scorer = new PostingWithClustersScorer(
             query.getFieldName(),


### PR DESCRIPTION
- During segment merge, DocValuesProducer and FieldProducer we get from MergeState are wrapped in a non-public class and the type check fail so that we didn't clear the memory. So I wrapped BinaryDocValues and segmentinfo, and it's always available.
- Add a fake setting and change its value to output logs of memory usage

```
PUT {{index}}/_settings
{
    "index.sparse.memory": true # change value to output log
}
```