### PR TITLE
Optimize getTerms from ms to micro seconds

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
@@ -19,8 +19,6 @@ import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 import org.opensearch.neuralsearch.sparse.common.MergeHelper;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A DocValuesConsumer that writes sparse doc values to a segment.

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
@@ -19,6 +19,8 @@ import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 import org.opensearch.neuralsearch.sparse.common.MergeHelper;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A DocValuesConsumer that writes sparse doc values to a segment.


### PR DESCRIPTION
- Revert change of changing term key from BytesRef to String
- Directly return innerMap.keySet() instead of copy set which save time from several ms to several micro seconds