### PR TITLE
Reduce memory usage from temparory data structure

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
@@ -19,8 +19,6 @@ import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 import org.opensearch.neuralsearch.sparse.common.MergeHelper;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A DocValuesConsumer that writes sparse doc values to a segment.

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
@@ -19,6 +19,8 @@ import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 import org.opensearch.neuralsearch.sparse.common.MergeHelper;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A DocValuesConsumer that writes sparse doc values to a segment.

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsReader.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsReader.java
@@ -25,11 +25,12 @@ import org.opensearch.neuralsearch.sparse.common.IteratorWrapper;
 import org.opensearch.neuralsearch.sparse.mapper.SparseMethodContext;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
 
 /**
  * Merge sparse postings
@@ -43,68 +44,15 @@ public class SparsePostingsReader {
     }
 
     public void merge() throws IOException, InterruptedException {
+        int docCount = 0;
+        for (int n : mergeState.maxDocs) {
+            docCount += n;
+        }
+        log.debug("Merge total doc: {}", docCount);
+
         for (FieldInfo fieldInfo : mergeState.mergeFieldInfos) {
             if (!SparseTokensField.isSparseField(fieldInfo)) {
                 continue;
-            }
-            Map<BytesRef, Set<DocFreq>> docs = new TreeMap<>();
-            Map<Integer, Pair<Integer, InMemoryKey.IndexKey>> newToOldDocIdMap = new HashMap<>();
-            for (int i = 0; i < this.mergeState.fieldsProducers.length; i++) {
-                FieldsProducer fieldsProducer = this.mergeState.fieldsProducers[i];
-                // we need this SparseBinaryDocValuesPassThrough to get segment info
-                BinaryDocValues binaryDocValues = this.mergeState.docValuesProducers[i].getBinary(fieldInfo);
-                if (!(binaryDocValues instanceof SparseBinaryDocValuesPassThrough)) {
-                    log.error("binaryDocValues is not SparseBinaryDocValuesPassThrough, {}", binaryDocValues.getClass().getName());
-                    continue;
-                }
-                Terms terms = fieldsProducer.terms(fieldInfo.name);
-                if (terms == null) {
-                    log.error("terms is null");
-                    continue;
-                }
-                TermsEnum termsEnum = terms.iterator();
-                if (termsEnum == null) {
-                    log.error("termsEnum is null");
-                    continue;
-                }
-                BytesRef term = termsEnum.next();
-                while (term != null) {
-                    if (!docs.containsKey(term)) {
-                        docs.put(term, new TreeSet<>());
-                    }
-                    PostingsEnum postings = termsEnum.postings(null);
-                    if (!(postings instanceof SparsePostingsEnum)) {
-                        log.error("postings is not SparsePostingsEnum, {}", postings);
-                        continue;
-                    }
-                    SparsePostingsEnum sparsePostingsEnum = (SparsePostingsEnum) postings;
-                    IteratorWrapper<DocumentCluster> clusterIter = sparsePostingsEnum.clusterIterator();
-                    while (clusterIter.next() != null) {
-                        DocFreqIterator docIter = clusterIter.getCurrent().getDisi();
-                        while (docIter.nextDoc() != PostingsEnum.NO_MORE_DOCS) {
-                            if (docIter.docID() == -1) {
-                                log.error("docId is -1");
-                                continue;
-                            }
-                            int newDocId = this.mergeState.docMaps[i].get(docIter.docID());
-                            if (newDocId == -1) {
-                                continue;
-                            }
-                            newToOldDocIdMap.put(
-                                newDocId,
-                                Pair.of(
-                                    docIter.docID(),
-                                    new InMemoryKey.IndexKey(
-                                        ((SparseBinaryDocValuesPassThrough) binaryDocValues).getSegmentInfo(),
-                                        fieldInfo
-                                    )
-                                )
-                            );
-                            docs.get(term).add(new DocFreq(newDocId, docIter.freq()));
-                        }
-                    }
-                    term = termsEnum.next();
-                }
             }
 
             InMemoryKey.IndexKey key = new InMemoryKey.IndexKey(mergeState.segmentInfo, fieldInfo);
@@ -112,23 +60,104 @@ public class SparsePostingsReader {
             int lambda = Integer.parseInt(fieldInfo.attributes().get(SparseMethodContext.LAMBDA_FIELD));
             float alpha = Float.parseFloat(fieldInfo.attributes().get(SparseMethodContext.ALPHA_FIELD));
             int clusterUtilDocCountReach = Integer.parseInt(fieldInfo.attributes().get(SparseMethodContext.CLUSTER_UNTIL_FIELD));
-            int docCount = 0;
-            for (int n : mergeState.maxDocs) {
-                docCount += n;
-            }
-            log.info("Merge total doc: {}", docCount);
+
             if (clusterUtilDocCountReach > 0 && docCount < clusterUtilDocCountReach) {
                 beta = 1;
             }
-            for (Map.Entry<BytesRef, Set<DocFreq>> entry : docs.entrySet()) {
+
+            // get all terms of old segments from InMemoryClusteredPosting
+            Set<BytesRef> allTerms = getAllTermsFromInMemoryClusteredPosting(fieldInfo);
+            for (BytesRef term : allTerms) {
+                Map<Integer, Pair<Integer, InMemoryKey.IndexKey>> newToOldDocIdMap = new HashMap<>();
+                List<DocFreq> docFreqs = getMergedPostingForATerm(term, fieldInfo, newToOldDocIdMap);
                 if (beta == 1) {
                     // not run asynchronously
-                    new ClusteringTask(entry.getKey(), entry.getValue(), key, alpha, beta, lambda, newToOldDocIdMap).run();
+                    new ClusteringTask(term, docFreqs, key, alpha, beta, lambda, newToOldDocIdMap).run();
                 } else {
                     ClusterTrainingRunning.getInstance()
-                        .run(new ClusteringTask(entry.getKey(), entry.getValue(), key, alpha, beta, lambda, newToOldDocIdMap));
+                        .run(new ClusteringTask(term, docFreqs, key, alpha, beta, lambda, newToOldDocIdMap));
                 }
             }
         }
+    }
+
+    // get all terms of old segments from InMemoryClusteredPosting
+    private Set<BytesRef> getAllTermsFromInMemoryClusteredPosting(FieldInfo fieldInfo) throws IOException {
+        Set<BytesRef> allTerms = new HashSet<>();
+        for (int i = 0; i < this.mergeState.fieldsProducers.length; i++) {
+            FieldsProducer fieldsProducer = this.mergeState.fieldsProducers[i];
+            // we need this SparseBinaryDocValuesPassThrough to get segment info
+            BinaryDocValues binaryDocValues = this.mergeState.docValuesProducers[i].getBinary(fieldInfo);
+            if (!(binaryDocValues instanceof SparseBinaryDocValuesPassThrough)) {
+                log.error("binaryDocValues is not SparseBinaryDocValuesPassThrough, {}", binaryDocValues.getClass().getName());
+                continue;
+            }
+            InMemoryKey.IndexKey oldKey = new InMemoryKey.IndexKey(
+                ((SparseBinaryDocValuesPassThrough) binaryDocValues).getSegmentInfo(),
+                fieldInfo
+            );
+            allTerms.addAll(new InMemoryClusteredPosting.InMemoryClusteredPostingReader(oldKey).getTerms());
+        }
+        return allTerms;
+    }
+
+    private List<DocFreq> getMergedPostingForATerm(
+        BytesRef term,
+        FieldInfo fieldInfo,
+        Map<Integer, Pair<Integer, InMemoryKey.IndexKey>> newToOldDocIdMap
+    ) throws IOException {
+        List<DocFreq> docFreqs = new ArrayList<>();
+        for (int i = 0; i < this.mergeState.fieldsProducers.length; i++) {
+            FieldsProducer fieldsProducer = this.mergeState.fieldsProducers[i];
+            // we need this SparseBinaryDocValuesPassThrough to get segment info
+            BinaryDocValues binaryDocValues = this.mergeState.docValuesProducers[i].getBinary(fieldInfo);
+            if (!(binaryDocValues instanceof SparseBinaryDocValuesPassThrough)) {
+                log.error("binaryDocValues is not SparseBinaryDocValuesPassThrough, {}", binaryDocValues.getClass().getName());
+                continue;
+            }
+            Terms terms = fieldsProducer.terms(fieldInfo.name);
+            if (terms == null) {
+                log.error("terms is null");
+                continue;
+            }
+
+            TermsEnum termsEnum = terms.iterator();
+            if (termsEnum == null) {
+                log.error("termsEnum is null");
+                continue;
+            }
+
+            if (termsEnum.seekCeil(term) == TermsEnum.SeekStatus.NOT_FOUND) {
+                continue;
+            }
+            PostingsEnum postings = termsEnum.postings(null);
+            if (!(postings instanceof SparsePostingsEnum)) {
+                log.error("postings is not SparsePostingsEnum, {}", postings);
+                continue;
+            }
+            InMemoryKey.IndexKey oldKey = new InMemoryKey.IndexKey(
+                ((SparseBinaryDocValuesPassThrough) binaryDocValues).getSegmentInfo(),
+                fieldInfo
+            );
+
+            SparsePostingsEnum sparsePostingsEnum = (SparsePostingsEnum) postings;
+            IteratorWrapper<DocumentCluster> clusterIter = sparsePostingsEnum.clusterIterator();
+            while (clusterIter.next() != null) {
+                DocFreqIterator docIter = clusterIter.getCurrent().getDisi();
+                while (docIter.nextDoc() != PostingsEnum.NO_MORE_DOCS) {
+                    if (docIter.docID() == -1) {
+                        log.error("docId is -1");
+                        continue;
+                    }
+                    int newDocId = this.mergeState.docMaps[i].get(docIter.docID());
+                    if (newDocId == -1) {
+                        continue;
+                    }
+                    newToOldDocIdMap.put(newDocId, Pair.of(docIter.docID(), oldKey));
+                    docFreqs.add(new DocFreq(newDocId, docIter.freq()));
+                }
+            }
+        }
+        return docFreqs;
     }
 }


### PR DESCRIPTION
`Map<BytesRef, Set<DocFreq>> docs = new TreeMap<>();` holds all posting data and it's referred by all threads which make it not garbage collectable. `newToOldDocIdMap` holds all docId mapping which could be 8.8M.
 
Break docs to separate List<DocFreq> so that it's only referred by the thread handle it and the memory can be reduced once the thread completes. And make newToOldDocIdMap to per term not global