### PR TITLE
Read/write clustered posting to lucene

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/ClusterTrainingRunning.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/ClusterTrainingRunning.java
@@ -6,6 +6,10 @@ package org.opensearch.neuralsearch.sparse.algorithm;
 
 import org.opensearch.threadpool.ThreadPool;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+
 public class ClusterTrainingRunning {
     private static ThreadPool threadpool = null;
     private static ClusterTrainingRunning INSTANCE;
@@ -22,7 +26,15 @@ public class ClusterTrainingRunning {
         return INSTANCE;
     }
 
+    public Executor getExecutor() {
+        return ClusterTrainingRunning.threadpool.executor(THREAD_POOL_NAME);
+    }
+
     public void run(Runnable runnable) {
         ClusterTrainingRunning.threadpool.executor(THREAD_POOL_NAME).execute(runnable);
+    }
+
+    public <T> Future<T> submit(Callable<T> callable) {
+        return ClusterTrainingRunning.threadpool.executor(THREAD_POOL_NAME).submit(callable);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/CacheGatedPostingsReader.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/CacheGatedPostingsReader.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.neuralsearch.sparse.algorithm.PostingClusters;
+import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
+
+import java.io.IOException;
+import java.util.Set;
+
+public class CacheGatedPostingsReader {
+    private final String field;
+    private final InMemoryClusteredPosting.InMemoryClusteredPostingReader inMemoryReader;
+    private final InMemoryKey.IndexKey indexKey;
+    // SparseTermsLuceneReader to read sparse terms from disk
+    private final SparseTermsLuceneReader luceneReader;
+
+    public CacheGatedPostingsReader(
+        String field,
+        InMemoryClusteredPosting.InMemoryClusteredPostingReader reader,
+        SparseTermsLuceneReader luceneReader,
+        InMemoryKey.IndexKey indexKey
+    ) {
+        this.field = field;
+        this.inMemoryReader = reader;
+        this.luceneReader = luceneReader;
+        this.indexKey = indexKey;
+    }
+
+    // we return terms from lucene as cache may not have all data due to memory constraint
+    public Set<BytesRef> terms() throws IOException {
+        return luceneReader.getTerms(field);
+    }
+
+    public long size() {
+        return luceneReader.getTerms(field).size();
+    }
+
+    public PostingClusters read(BytesRef term) throws IOException {
+        PostingClusters clusters = inMemoryReader.read(term);
+        // if cluster does not exist in cache, read from lucene and populate it to cache
+        if (clusters == null) {
+            clusters = luceneReader.read(field, term);
+            if (clusters != null) {
+                InMemoryClusteredPosting.InMemoryClusteredPostingWriter.writePostingClusters(indexKey, term, clusters.getClusters());
+            }
+        }
+        return clusters;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriter.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriter.java
@@ -4,58 +4,180 @@
  */
 package org.opensearch.neuralsearch.sparse.codec;
 
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.BlockTermState;
+import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.NormsProducer;
-import org.apache.lucene.codecs.PostingsWriterBase;
+import org.apache.lucene.codecs.PushPostingsWriterBase;
+import org.apache.lucene.codecs.lucene101.Lucene101PostingsFormat;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.IOUtils;
+import org.opensearch.neuralsearch.sparse.algorithm.ClusteringTask;
+import org.opensearch.neuralsearch.sparse.algorithm.DocumentCluster;
+import org.opensearch.neuralsearch.sparse.algorithm.PostingClusters;
 import org.opensearch.neuralsearch.sparse.algorithm.RandomClustering;
 import org.opensearch.neuralsearch.sparse.algorithm.PostingClustering;
+import org.opensearch.neuralsearch.sparse.common.DocFreq;
 import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
+import org.opensearch.neuralsearch.sparse.common.IteratorWrapper;
+import org.opensearch.neuralsearch.sparse.common.SparseVector;
+import org.opensearch.neuralsearch.sparse.common.ValueEncoder;
 import org.opensearch.neuralsearch.sparse.mapper.SparseMethodContext;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * ClusteredPostingTermsWriter is used to write postings for each segment
+ * ClusteredPostingTermsWriter is used to write postings for each segment.
+ * It handles the logic to write data to both in-memory and lucene index.
  */
-public class ClusteredPostingTermsWriter {
-    private final PostingsWriterBase postingsWriter;
-    private final FixedBitSet docsSeen;
+@Log4j2
+public class ClusteredPostingTermsWriter extends PushPostingsWriterBase {
+    private FixedBitSet docsSeen;
+    private IndexOutput postingOut;
+    private final List<DocFreq> docFreqs = new ArrayList<>();
+    private BytesRef currentTerm;
+    private PostingClustering postingClustering;
+    private InMemoryKey.IndexKey key;
+    private SegmentInfo segmentInfo;
+    private final int version;
+    private final String codec_name;
 
-    public ClusteredPostingTermsWriter(SegmentWriteState state, FieldInfo fieldInfo) {
+    public ClusteredPostingTermsWriter(String codec_name, int version) {
         super();
-        InMemoryKey.IndexKey key = new InMemoryKey.IndexKey(state.segmentInfo, fieldInfo);
-        SparseVectorForwardIndex index = InMemorySparseVectorForwardIndex.get(key);
+        this.version = version;
+        this.codec_name = codec_name;
+    }
+
+    public BlockTermState write(BytesRef text, TermsEnum termsEnum, NormsProducer norms) throws IOException {
+        this.currentTerm = text;
+        return super.writeTerm(text, termsEnum, docsSeen, norms);
+    }
+
+    public BlockTermState write(BytesRef text, PostingClusters postingClusters) throws IOException {
+        this.currentTerm = text;
+        BlockTermState state = newTermState();
+        writePostingClusters(postingClusters, state);
+        return state;
+    }
+
+    @Override
+    public void setField(FieldInfo fieldInfo) {
+        super.setField(fieldInfo);
+        key = new InMemoryKey.IndexKey(this.segmentInfo, fieldInfo);
+        SparseVectorForwardIndex index = InMemorySparseVectorForwardIndex.getOrCreate(key);
         assert (index != null);
         int beta = Integer.parseInt(fieldInfo.attributes().get(SparseMethodContext.BETA_FIELD));
         int lambda = Integer.parseInt(fieldInfo.attributes().get(SparseMethodContext.LAMBDA_FIELD));
         float alpha = Float.parseFloat(fieldInfo.attributes().get(SparseMethodContext.ALPHA_FIELD));
         int clusterUntilDocCountReach = Integer.parseInt(fieldInfo.attributes().get(SparseMethodContext.CLUSTER_UNTIL_FIELD));
-        this.postingsWriter = new InMemoryClusteredPosting.InMemoryClusteredPostingWriter(
-            key,
-            fieldInfo,
-            new PostingClustering(
+        this.postingClustering = new PostingClustering(
+            lambda,
+            new RandomClustering(
                 lambda,
-                new RandomClustering(
-                    lambda,
-                    alpha,
-                    clusterUntilDocCountReach > 0 ? 1 : beta,
-                    (docId) -> index.getForwardIndexReader().readSparseVector(docId)
-                ),
-                clusterUntilDocCountReach > 0 ? 1 : beta
-            )
+                alpha,
+                clusterUntilDocCountReach > 0 ? 1 : beta,
+                (docId) -> index.getForwardIndexReader().readSparseVector(docId)
+            ),
+            clusterUntilDocCountReach > 0 ? 1 : beta
         );
-        this.docsSeen = new FixedBitSet(state.segmentInfo.maxDoc());
     }
 
-    public void write(BytesRef text, TermsEnum termsEnum, NormsProducer norms) throws IOException {
-        if (this.postingsWriter instanceof InMemoryClusteredPosting.InMemoryClusteredPostingWriter writer) {
-            writer.writeInMemoryTerm(text, termsEnum, this.docsSeen, norms);
-        } else {
-            throw new RuntimeException("not support");
+    @Override
+    public BlockTermState newTermState() throws IOException {
+        return new Lucene101PostingsFormat.IntBlockTermState();
+    }
+
+    @Override
+    public void startTerm(NumericDocValues norms) throws IOException {
+        docFreqs.clear();
+    }
+
+    private void writePostingClusters(PostingClusters postingClusters, BlockTermState state) throws IOException {
+        List<DocumentCluster> clusters = postingClusters.getClusters();
+        // write file
+        state.blockFilePointer = postingOut.getFilePointer();
+        postingOut.writeVLong(clusters.size());
+        for (DocumentCluster cluster : clusters) {
+            postingOut.writeVLong(cluster.getDocs().size());
+            for (DocFreq docFreq : cluster.getDocs()) {
+                postingOut.writeVInt(docFreq.getDocID());
+                postingOut.writeVInt(ValueEncoder.encodeFeatureValue(docFreq.getFreq()));
+            }
+            postingOut.writeByte((byte) (cluster.isShouldNotSkip() ? 1 : 0));
+            if (cluster.getSummary() == null) {
+                postingOut.writeVLong(0);
+            } else {
+                IteratorWrapper<SparseVector.Item> iter = cluster.getSummary().iterator();
+                postingOut.writeVLong(cluster.getSummary().getSize());
+                while (iter.hasNext()) {
+                    SparseVector.Item item = iter.next();
+                    postingOut.writeVInt(item.getToken());
+                    postingOut.writeVInt(ValueEncoder.encodeFeatureValue(item.getFreq()));
+                }
+            }
         }
+    }
+
+    @Override
+    public void finishTerm(BlockTermState state) throws IOException {
+        PostingClusters postingClusters = new ClusteringTask(this.currentTerm, docFreqs, key, this.postingClustering).get();
+        writePostingClusters(postingClusters, state);
+        this.docFreqs.clear();
+        this.currentTerm = null;
+    }
+
+    @Override
+    public void startDoc(int docID, int freq) throws IOException {
+        if (docID == -1) {
+            throw new IllegalStateException("docId must be set before startDoc");
+        }
+        docFreqs.add(new DocFreq(docID, ValueEncoder.decodeFeatureValue(freq)));
+    }
+
+    @Override
+    public void addPosition(int position, BytesRef payload, int startOffset, int endOffset) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void finishDoc() throws IOException {
+
+    }
+
+    @Override
+    public void init(IndexOutput termsOut, SegmentWriteState state) throws IOException {
+        this.postingOut = termsOut;
+        this.segmentInfo = state.segmentInfo;
+        this.docsSeen = new FixedBitSet(state.segmentInfo.maxDoc());
+        CodecUtil.writeIndexHeader(postingOut, this.codec_name, version, state.segmentInfo.getId(), state.segmentSuffix);
+    }
+
+    @Override
+    public void encodeTerm(DataOutput out, FieldInfo fieldInfo, BlockTermState state, boolean absolute) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() throws IOException {
+        CodecUtil.writeFooter(this.postingOut);
+    }
+
+    public void closeWithException() {
+        IOUtils.closeWhileHandlingException(this.postingOut);
+    }
+
+    public void close(long startFp) throws IOException {
+        this.postingOut.writeLong(startFp);
+        close();
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/InMemoryClusteredPosting.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/InMemoryClusteredPosting.java
@@ -5,28 +5,13 @@
 package org.opensearch.neuralsearch.sparse.codec;
 
 import lombok.AllArgsConstructor;
-import org.apache.lucene.codecs.BlockTermState;
-import org.apache.lucene.codecs.NormsProducer;
-import org.apache.lucene.codecs.PushPostingsWriterBase;
-import org.apache.lucene.codecs.lucene101.Lucene101PostingsFormat;
-import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.NumericDocValues;
-import org.apache.lucene.index.SegmentWriteState;
-import org.apache.lucene.index.TermsEnum;
-import org.apache.lucene.store.DataOutput;
-import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.opensearch.neuralsearch.sparse.algorithm.DocumentCluster;
-import org.opensearch.neuralsearch.sparse.algorithm.PostingClustering;
 import org.opensearch.neuralsearch.sparse.algorithm.PostingClusters;
-import org.opensearch.neuralsearch.sparse.common.DocFreq;
 import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -42,20 +27,6 @@ public class InMemoryClusteredPosting implements Accountable {
 
     public static void clearIndex(InMemoryKey.IndexKey key) {
         inMemoryPostings.remove(key);
-    }
-
-    static final int MAX_FREQ = Float.floatToIntBits(Float.MAX_VALUE) >>> 15;
-
-    static float decodeFeatureValue(float freq) {
-        if (freq > MAX_FREQ) {
-            // This is never used in practice but callers of the SimScorer API might
-            // occasionally call it on eg. Float.MAX_VALUE to compute the max score
-            // so we need to be consistent.
-            return Float.MAX_VALUE;
-        }
-        int tf = (int) freq; // lossless
-        int featureBits = tf << 15;
-        return Float.intBitsToFloat(featureBits);
     }
 
     @Override
@@ -79,96 +50,33 @@ public class InMemoryClusteredPosting implements Accountable {
             return inMemoryPostings.getOrDefault(key, Collections.emptyMap()).get(term);
         }
 
+        // once we enable cache eviction, this method will get partial data and should be removed.
         public Set<BytesRef> getTerms() {
             Map<BytesRef, PostingClusters> innerMap = inMemoryPostings.get(key);
             return innerMap != null ? innerMap.keySet() : Collections.emptySet();
         }
 
+        public long size() {
+            return inMemoryPostings.get(key).size();
+        }
     }
 
-    public static class InMemoryClusteredPostingWriter extends PushPostingsWriterBase {
-
-        private List<DocFreq> docFreqs = new ArrayList<>();
-        private BytesRef currentTerm;
-        private final PostingClustering postingClustering;
-        private final InMemoryKey.IndexKey key;
-
-        public InMemoryClusteredPostingWriter(InMemoryKey.IndexKey key, FieldInfo fieldInfo, PostingClustering postingClustering) {
-            super();
-            setField(fieldInfo);
-            this.key = key;
-            this.postingClustering = postingClustering;
-        }
-
-        public BlockTermState writeInMemoryTerm(BytesRef term, TermsEnum termsEnum, FixedBitSet docsSeen, NormsProducer norms)
-            throws IOException {
-            this.currentTerm = term;
-            return super.writeTerm(term, termsEnum, docsSeen, norms);
-        }
-
-        @Override
-        public BlockTermState newTermState() throws IOException {
-            return new Lucene101PostingsFormat.IntBlockTermState();
-        }
-
-        @Override
-        public void startTerm(NumericDocValues norms) throws IOException {
-            docFreqs.clear();
-        }
-
-        public static void writePostingClusters(InMemoryKey.IndexKey key, BytesRef term, List<DocumentCluster> clusters) {
+    public static class InMemoryClusteredPostingWriter {
+        public static Map<BytesRef, PostingClusters> writePostingClusters(
+            InMemoryKey.IndexKey key,
+            BytesRef term,
+            List<DocumentCluster> clusters
+        ) {
             if (clusters == null || clusters.isEmpty()) {
-                return;
+                return null;
             }
-
-            inMemoryPostings.compute(key, (k, existingMap) -> {
-                if (existingMap == null) {
-                    existingMap = new ConcurrentHashMap<>();
-                }
-                existingMap.put(term.clone(), new PostingClusters(clusters));
-                return existingMap;
-            });
-        }
-
-        @Override
-        public void finishTerm(BlockTermState state) throws IOException {
-            List<DocumentCluster> clusters = this.postingClustering.cluster(docFreqs);
-            writePostingClusters(key, this.currentTerm, clusters);
-            this.docFreqs.clear();
-            this.currentTerm = null;
-        }
-
-        @Override
-        public void startDoc(int docID, int freq) throws IOException {
-            if (docID == -1) {
-                throw new IllegalStateException("docId must be set before startDoc");
-            }
-            docFreqs.add(new DocFreq(docID, decodeFeatureValue(freq)));
-        }
-
-        @Override
-        public void addPosition(int position, BytesRef payload, int startOffset, int endOffset) throws IOException {
-
-        }
-
-        @Override
-        public void finishDoc() throws IOException {
-
-        }
-
-        @Override
-        public void init(IndexOutput termsOut, SegmentWriteState state) throws IOException {
-
-        }
-
-        @Override
-        public void encodeTerm(DataOutput out, FieldInfo fieldInfo, BlockTermState state, boolean absolute) throws IOException {
-
-        }
-
-        @Override
-        public void close() throws IOException {
-
+             return inMemoryPostings.compute(key, (k, existingMap) -> {
+                 if (existingMap == null) {
+                     existingMap = new ConcurrentHashMap<>();
+                 }
+                 existingMap.put(term.clone(), new PostingClusters(clusters));
+                 return existingMap;
+             });
         }
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
@@ -19,8 +19,6 @@ import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 import org.opensearch.neuralsearch.sparse.common.MergeHelper;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A DocValuesConsumer that writes sparse doc values to a segment.

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
@@ -19,6 +19,8 @@ import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 import org.opensearch.neuralsearch.sparse.common.MergeHelper;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A DocValuesConsumer that writes sparse doc values to a segment.

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumer.java
@@ -5,15 +5,19 @@
 package org.opensearch.neuralsearch.sparse.codec;
 
 import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.BlockTermState;
 import org.apache.lucene.codecs.FieldsConsumer;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.IOUtils;
 import org.opensearch.neuralsearch.sparse.SparseTokensField;
 import org.opensearch.neuralsearch.sparse.common.MergeHelper;
 
@@ -30,10 +34,97 @@ public class SparsePostingsConsumer extends FieldsConsumer {
     private final FieldsConsumer delegate;
     private final SegmentWriteState state;
 
-    public SparsePostingsConsumer(FieldsConsumer delegate, SegmentWriteState state) {
+    static final String CODEC_NAME = "SparsePostingsProducer";
+    private final IndexOutput termsOut;
+    private final IndexOutput postingOut;
+    private final SparseTermsLuceneWriter sparseTermsLuceneWriter;
+
+    // Initial format
+    public static final int VERSION_START = 1;
+    public static final int VERSION_CURRENT = VERSION_START;
+
+    /** Extension of terms file */
+    static final String TERMS_EXTENSION = "sit";
+    static final String POSTING_EXTENSION = "sip";
+
+    private final ClusteredPostingTermsWriter clusteredPostingTermsWriter;
+    private long termsStartFp = 0;
+    private long postingStartFp = 0;
+    private boolean fromMerge = false;
+
+    public SparsePostingsConsumer(FieldsConsumer delegate, SegmentWriteState state) throws IOException {
+        this(delegate, state, VERSION_CURRENT);
+    }
+
+    public SparsePostingsConsumer(FieldsConsumer delegate, SegmentWriteState state, int version) throws IOException {
         super();
         this.delegate = delegate;
         this.state = state;
+
+        final String termsFileName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, TERMS_EXTENSION);
+        final String postingFileName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, POSTING_EXTENSION);
+
+        clusteredPostingTermsWriter = new ClusteredPostingTermsWriter(CODEC_NAME, version);
+        sparseTermsLuceneWriter = new SparseTermsLuceneWriter(CODEC_NAME, version);
+
+        boolean success = false;
+        IndexOutput termsOut = null;
+        IndexOutput postingOut = null;
+        try {
+            termsOut = state.directory.createOutput(termsFileName, state.context);
+            sparseTermsLuceneWriter.init(termsOut, state);
+            postingOut = state.directory.createOutput(postingFileName, state.context);
+            clusteredPostingTermsWriter.init(postingOut, state);
+
+            success = true;
+        } finally {
+            if (!success) {
+                IOUtils.closeWhileHandlingException(termsOut, postingOut);
+                this.termsOut = null;
+                this.postingOut = null;
+            } else {
+                this.termsOut = termsOut;
+                this.postingOut = postingOut;
+                termsStartFp = termsOut.getFilePointer();
+                postingStartFp = postingOut.getFilePointer();
+            }
+        }
+    }
+
+    private void writeSparseTerms(Fields fields, NormsProducer norms, List<String> sparseFields) throws IOException {
+        this.sparseTermsLuceneWriter.writeFieldCount(sparseFields.size());
+
+        String lastField = null;
+        for (String field : sparseFields) {
+            assert lastField == null || lastField.compareTo(field) < 0;
+            lastField = field;
+            this.sparseTermsLuceneWriter.writeFieldNumber(this.state.fieldInfos.fieldInfo(field).number);
+
+            Terms terms = fields.terms(field);
+            if (terms == null) {
+                this.sparseTermsLuceneWriter.writeTermsSize(0);
+                continue;
+            }
+
+            this.clusteredPostingTermsWriter.setField(this.state.fieldInfos.fieldInfo(field));
+
+            TermsEnum termsEnum = terms.iterator();
+            List<BytesRef> termsList = new ArrayList<>();
+            List<BlockTermState> states = new ArrayList<>();
+            while (true) {
+                BytesRef term = termsEnum.next();
+                if (term == null) {
+                    break;
+                }
+                BlockTermState state = this.clusteredPostingTermsWriter.write(term, termsEnum, norms);
+                termsList.add(term.clone());
+                states.add(state);
+            }
+            this.sparseTermsLuceneWriter.writeTermsSize(termsList.size());
+            for (int i = 0; i < termsList.size(); ++i) {
+                this.sparseTermsLuceneWriter.writeTerm(termsList.get(i), states.get(i));
+            }
+        }
     }
 
     @Override
@@ -57,42 +148,21 @@ public class SparsePostingsConsumer extends FieldsConsumer {
             this.delegate.write(maskedFields, norms);
         }
 
-        String lastField = null;
-        for (String field : sparseFields) {
-            assert lastField == null || lastField.compareTo(field) < 0;
-            lastField = field;
-
-            Terms terms = fields.terms(field);
-            if (terms == null) {
-                continue;
-            }
-
-            ClusteredPostingTermsWriter clusteredPostingTermsWriter = new ClusteredPostingTermsWriter(
-                this.state,
-                this.state.fieldInfos.fieldInfo(field)
-            );
-
-            TermsEnum termsEnum = terms.iterator();
-            while (true) {
-                BytesRef term = termsEnum.next();
-                if (term == null) {
-                    break;
-                }
-                clusteredPostingTermsWriter.write(term, termsEnum, norms);
-            }
-
-            // termsWriter.finish();
+        // if this is not a merge, write the sparse fields, if it's from merge, we handle it from merge()
+        if (!this.fromMerge) {
+            writeSparseTerms(fields, norms, sparseFields);
         }
     }
 
     @Override
     public void merge(MergeState mergeState, NormsProducer norms) throws IOException {
+        this.fromMerge = true;
         // merge non-sparse fields
         super.merge(mergeState, norms);
         // merge sparse fields
         try {
             SparsePostingsReader sparsePostingsReader = new SparsePostingsReader(mergeState);
-            sparsePostingsReader.merge();
+            sparsePostingsReader.merge(this.sparseTermsLuceneWriter, this.clusteredPostingTermsWriter);
             MergeHelper.clearInMemoryData(mergeState, null, InMemoryClusteredPosting::clearIndex);
         } catch (Exception e) {
             log.error("Merge sparse postings error", e);
@@ -102,5 +172,17 @@ public class SparsePostingsConsumer extends FieldsConsumer {
     @Override
     public void close() throws IOException {
         this.delegate.close();
+        boolean success = false;
+        try {
+            this.sparseTermsLuceneWriter.close(this.termsStartFp);
+            this.clusteredPostingTermsWriter.close(this.postingStartFp);
+            success = true;
+        } finally {
+            if (success) {
+                IOUtils.close(termsOut, postingOut);
+            } else {
+                IOUtils.closeWhileHandlingException(termsOut, postingOut);
+            }
+        }
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsProducer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsProducer.java
@@ -24,16 +24,19 @@ public class SparsePostingsProducer extends FieldsProducer {
 
     private final FieldsProducer delegate;
     private final SegmentReadState state;
+    private final SparseTermsLuceneReader reader;
 
-    public SparsePostingsProducer(FieldsProducer delegate, SegmentReadState state) {
+    public SparsePostingsProducer(FieldsProducer delegate, SegmentReadState state) throws IOException {
         super();
         this.delegate = delegate;
         this.state = state;
+        this.reader = new SparseTermsLuceneReader(state);
     }
 
     @Override
     public void close() throws IOException {
         this.delegate.close();
+        this.reader.close();
     }
 
     @Override
@@ -53,8 +56,7 @@ public class SparsePostingsProducer extends FieldsProducer {
             return delegate.terms(field);
         }
         InMemoryKey.IndexKey key = new InMemoryKey.IndexKey(this.state.segmentInfo, fieldInfo);
-        InMemoryClusteredPosting.InMemoryClusteredPostingReader reader = new InMemoryClusteredPosting.InMemoryClusteredPostingReader(key);
-        return new SparseTerms(reader, key);
+        return new SparseTerms(key, reader, field);
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneReader.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneReader.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.IOUtils;
+import org.opensearch.neuralsearch.sparse.algorithm.DocumentCluster;
+import org.opensearch.neuralsearch.sparse.algorithm.PostingClusters;
+import org.opensearch.neuralsearch.sparse.common.DocFreq;
+import org.opensearch.neuralsearch.sparse.common.SparseVector;
+import org.opensearch.neuralsearch.sparse.common.ValueEncoder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class read terms and clustered posting from lucene index.
+ * It stores the posting to in-memory data structure.
+ */
+@Log4j2
+public class SparseTermsLuceneReader extends FieldsProducer {
+    private final Map<String, Map<BytesRef, Long>> fieldToTerms = new HashMap<>();
+    private IndexInput termsIn;
+    private IndexInput postingIn;
+    private final SegmentInfo segmentInfo;
+
+    public SparseTermsLuceneReader(SegmentReadState state) {
+        this.segmentInfo = state.segmentInfo;
+
+        final String termsFileName = IndexFileNames.segmentFileName(
+            state.segmentInfo.name,
+            state.segmentSuffix,
+            SparsePostingsConsumer.TERMS_EXTENSION
+        );
+        final String postingFileName = IndexFileNames.segmentFileName(
+            state.segmentInfo.name,
+            state.segmentSuffix,
+            SparsePostingsConsumer.POSTING_EXTENSION
+        );
+        boolean success = false;
+        try {
+            termsIn = state.directory.openInput(termsFileName, state.context);
+            CodecUtil.checkIndexHeader(
+                termsIn,
+                SparsePostingsConsumer.CODEC_NAME,
+                SparsePostingsConsumer.VERSION_START,
+                SparsePostingsConsumer.VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix
+            );
+            CodecUtil.retrieveChecksum(termsIn);
+            seekDir(termsIn);
+
+            postingIn = state.directory.openInput(postingFileName, state.context);
+            CodecUtil.checkIndexHeader(
+                postingIn,
+                SparsePostingsConsumer.CODEC_NAME,
+                SparsePostingsConsumer.VERSION_START,
+                SparsePostingsConsumer.VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix
+            );
+            CodecUtil.retrieveChecksum(postingIn);
+
+            int numberOfFields = termsIn.readVInt();
+            for (int i = 0; i < numberOfFields; i++) {
+                int fieldId = termsIn.readVInt();
+                int numberOfTerms = (int) termsIn.readVLong();
+                Map<BytesRef, Long> terms = new HashMap<>(numberOfTerms);
+                for (int j = 0; j < numberOfTerms; j++) {
+                    int byteLength = termsIn.readVInt();
+                    BytesRef term = new BytesRef(byteLength);
+                    term.length = byteLength;
+                    try {
+                        termsIn.readBytes(term.bytes, term.offset, byteLength);
+                    } catch (Exception e) {
+                        throw e;
+                    }
+                    long fileOffset = termsIn.readVLong();
+                    terms.put(term, fileOffset);
+                }
+                fieldToTerms.put(state.fieldInfos.fieldInfo(fieldId).name, terms);
+            }
+            success = true;
+        } catch (Exception e) {
+            log.error("Read sparse terms error", e);
+        } finally {
+            if (success) {} else {
+                IOUtils.closeWhileHandlingException(termsIn, postingIn);
+            }
+        }
+    }
+
+    private void seekDir(IndexInput input) throws IOException {
+        input.seek(input.length() - CodecUtil.footerLength() - 8);
+        long dirOffset = input.readLong();
+        input.seek(dirOffset);
+    }
+
+    @Override
+    public Iterator<String> iterator() {
+        return fieldToTerms.keySet().iterator();
+    }
+
+    private List<DocumentCluster> readClusters(long offset) throws IOException {
+        postingIn.seek(offset);
+        long clusterSize = postingIn.readVLong();
+        List<DocumentCluster> clusters = new ArrayList<>((int) clusterSize);
+        for (int j = 0; j < clusterSize; j++) {
+            long docSize = postingIn.readVLong();
+            List<DocFreq> docs = new ArrayList<>((int) docSize);
+            for (int k = 0; k < docSize; ++k) {
+                docs.add(new DocFreq(postingIn.readVInt(), ValueEncoder.decodeFeatureValue(postingIn.readVInt())));
+            }
+            boolean shouldNotSkip = postingIn.readByte() == 1;
+            // summary
+            long summaryVectorSize = postingIn.readVLong();
+            List<SparseVector.Item> items = new ArrayList<>((int) summaryVectorSize);
+            for (int k = 0; k < summaryVectorSize; ++k) {
+                items.add(new SparseVector.Item(postingIn.readVInt(), ValueEncoder.decodeFeatureValue(postingIn.readVInt())));
+            }
+            SparseVector summary = items.isEmpty() ? null : new SparseVector(items);
+            DocumentCluster cluster = new DocumentCluster(summary, docs, shouldNotSkip);
+            clusters.add(cluster);
+        }
+        return clusters;
+    }
+
+    @Override
+    public Terms terms(String field) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    public Set<BytesRef> getTerms(String field) {
+        Map<BytesRef, Long> termsMapping = fieldToTerms.get(field);
+        if (termsMapping == null) {
+            return Collections.EMPTY_SET;
+        }
+        return termsMapping.keySet();
+    }
+
+    public PostingClusters read(String field, BytesRef term) throws IOException {
+        Map<BytesRef, Long> termsMapping = fieldToTerms.get(field);
+        if (termsMapping == null) {
+            return null;
+        }
+        if (!termsMapping.containsKey(term)) {
+            return null;
+        }
+        long offset = termsMapping.get(term);
+        List<DocumentCluster> clusters = readClusters(offset);
+        return new PostingClusters(clusters);
+    }
+
+    @Override
+    public int size() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(this.termsIn, this.postingIn);
+    }
+
+    @Override
+    public void checkIntegrity() throws IOException {
+
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneWriter.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneWriter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.codecs.BlockTermState;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.IOUtils;
+
+import java.io.IOException;
+
+public class SparseTermsLuceneWriter {
+    private IndexOutput termsOut;
+    private final int version;
+    private final String codec_name;
+
+    public SparseTermsLuceneWriter(String codec_name, int version) {
+        this.codec_name = codec_name;
+        this.version = version;
+    }
+
+    public void init(IndexOutput termsOut, SegmentWriteState state) throws IOException {
+        this.termsOut = termsOut;
+        CodecUtil.writeIndexHeader(termsOut, codec_name, version, state.segmentInfo.getId(), state.segmentSuffix);
+    }
+
+    public void close(long startFp) throws IOException {
+        this.termsOut.writeLong(startFp);
+        CodecUtil.writeFooter(this.termsOut);
+    }
+
+    public void writeFieldCount(int fieldCount) throws IOException {
+        termsOut.writeVInt(fieldCount);
+    }
+
+    public void writeFieldNumber(int fieldNumber) throws IOException {
+        termsOut.writeVInt(fieldNumber);
+    }
+
+    public void writeTermsSize(long termsSize) throws IOException {
+        termsOut.writeVLong(termsSize);
+    }
+
+    public void writeTerm(BytesRef term, BlockTermState state) throws IOException {
+        this.termsOut.writeVInt(term.length);
+        this.termsOut.writeBytes(term.bytes, term.offset, term.length);
+        this.termsOut.writeVLong(state.blockFilePointer);
+    }
+
+    public void closeWithException() {
+        IOUtils.closeWhileHandlingException(this.termsOut);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/common/SparseVector.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/common/SparseVector.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
  */
 @EqualsAndHashCode
 public class SparseVector implements Accountable {
+    @Getter
     private final int size;
     // tokens will be stored in order
     private short[] tokens;
@@ -42,11 +43,6 @@ public class SparseVector implements Accountable {
 
     private static Integer convertStringToInteger(String value) {
         return NumberUtils.createInteger(value);
-    }
-
-    private static Integer convertFloatToInteger(Float value) {
-        int freqBits = Float.floatToIntBits(value);
-        return freqBits >>> 15;
     }
 
     public SparseVector(List<Item> items) {

--- a/src/main/java/org/opensearch/neuralsearch/sparse/common/ValueEncoder.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/common/ValueEncoder.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.common;
+
+public class ValueEncoder {
+    static final int MAX_FREQ = Float.floatToIntBits(Float.MAX_VALUE) >>> 15;
+
+    public static int encodeFeatureValue(float featureValue) {
+        int freqBits = Float.floatToIntBits(featureValue);
+        return freqBits >>> 15;
+    }
+
+    public static float decodeFeatureValue(float freq) {
+        if (freq > MAX_FREQ) {
+            // This is never used in practice but callers of the SimScorer API might
+            // occasionally call it on eg. Float.MAX_VALUE to compute the max score
+            // so we need to be consistent.
+            return Float.MAX_VALUE;
+        }
+        int tf = (int) freq; // lossless
+        int featureBits = tf << 15;
+        return Float.intBitsToFloat(featureBits);
+    }
+}


### PR DESCRIPTION
1. read/write posting to lucene
2. posting clustering tasks need to complete before binary merge begins
3. now read terms will read from lucene file which may impact speed. (warm up request should make it load into memory)