### PR TITLE
Reduce RAM usage

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/BinaryDocValuesSub.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/BinaryDocValuesSub.java
@@ -4,33 +4,37 @@
  */
 package org.opensearch.neuralsearch.sparse.codec;
 
+import lombok.Getter;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocIDMerger;
 import org.apache.lucene.index.MergeState;
+import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 
 import java.io.IOException;
 
 /**
  * It holds binary doc values sub for each segment. It is used to merge doc values from multiple segments.
  */
+@Getter
 public class BinaryDocValuesSub extends DocIDMerger.Sub {
 
     private final BinaryDocValues values;
+    private final InMemoryKey.IndexKey key;
+    private int docId = 0;
 
-    public BinaryDocValuesSub(MergeState.DocMap docMap, BinaryDocValues values) {
+    public BinaryDocValuesSub(MergeState.DocMap docMap, BinaryDocValues values, InMemoryKey.IndexKey key) {
         super(docMap);
         if (values == null || (values.docID() != -1)) {
             throw new IllegalStateException("Doc values is either null or docID is not -1 ");
         }
         this.values = values;
+        this.key = key;
     }
 
     @Override
     public int nextDoc() throws IOException {
-        return values.nextDoc();
+        docId = values.nextDoc();
+        return docId;
     }
 
-    public BinaryDocValues getValues() {
-        return values;
-    }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriter.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriter.java
@@ -34,6 +34,7 @@ import org.opensearch.neuralsearch.sparse.mapper.SparseMethodContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -107,8 +108,10 @@ public class ClusteredPostingTermsWriter extends PushPostingsWriterBase {
         state.blockFilePointer = postingOut.getFilePointer();
         postingOut.writeVLong(clusters.size());
         for (DocumentCluster cluster : clusters) {
-            postingOut.writeVLong(cluster.getDocs().size());
-            for (DocFreq docFreq : cluster.getDocs()) {
+            postingOut.writeVLong(cluster.size());
+            Iterator<DocFreq> iterator = cluster.iterator();
+            while (iterator.hasNext()) {
+                DocFreq docFreq = iterator.next();
                 postingOut.writeVInt(docFreq.getDocID());
                 postingOut.writeVInt(ValueEncoder.encodeFeatureValue(docFreq.getFreq()));
             }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/InMemorySparseVectorForwardIndex.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/InMemorySparseVectorForwardIndex.java
@@ -72,7 +72,7 @@ public class InMemorySparseVectorForwardIndex implements SparseVectorForwardInde
         long ramUsed = 0;
         for (SparseVector vector : sparseVectors) {
             if (vector == null) continue;
-            ramUsed += RamUsageEstimator.shallowSizeOfInstance(SparseVector.class);
+            ramUsed += vector.ramBytesUsed();
         }
         return ramUsed;
     }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValues.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValues.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocIDMerger;
 import org.apache.lucene.util.BytesRef;
+import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
+import org.opensearch.neuralsearch.sparse.common.SparseVector;
 
 import java.io.IOException;
 
@@ -61,6 +63,17 @@ public class SparseBinaryDocValues extends BinaryDocValues {
     @Override
     public BytesRef binaryValue() throws IOException {
         return current.getValues().binaryValue();
+    }
+
+    public SparseVector cachedSparseVector() throws IOException {
+        if (this.current == null) return null;
+        InMemoryKey.IndexKey key = this.current.getKey();
+        if (key == null) return null;
+        InMemorySparseVectorForwardIndex index = InMemorySparseVectorForwardIndex.get(key);
+        if (index == null) return null;
+        InMemorySparseVectorForwardIndex.SparseVectorForwardIndexReader reader = index.getForwardIndexReader();
+        int oldDocId = this.current.getDocId();
+        return reader.readSparseVector(oldDocId);
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
@@ -19,8 +19,6 @@ import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 import org.opensearch.neuralsearch.sparse.common.MergeHelper;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A DocValuesConsumer that writes sparse doc values to a segment.

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
@@ -19,6 +19,8 @@ import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 import org.opensearch.neuralsearch.sparse.common.MergeHelper;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A DocValuesConsumer that writes sparse doc values to a segment.

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesReader.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesReader.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.MergeState;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.Bits;
+import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -44,12 +45,16 @@ public class SparseDocValuesReader extends EmptyDocValuesProducer {
                         values = docValuesProducer.getBinary(readerFieldInfo);
                     }
                     if (values != null) {
+                        InMemoryKey.IndexKey key = null;
+                        if (values instanceof SparseBinaryDocValuesPassThrough) {
+                            SparseBinaryDocValuesPassThrough sparseBinaryDocValuesPassThrough = (SparseBinaryDocValuesPassThrough) values;
+                            key = new InMemoryKey.IndexKey(sparseBinaryDocValuesPassThrough.getSegmentInfo(), field);
+                        }
                         totalLiveDocs = totalLiveDocs + getLiveDocsCount(values, this.mergeState.liveDocs[i]);
                         // docValues will be consumed when liveDocs are not null, hence resetting the docsValues
                         // pointer.
                         values = this.mergeState.liveDocs[i] != null ? docValuesProducer.getBinary(readerFieldInfo) : values;
-
-                        subs.add(new BinaryDocValuesSub(mergeState.docMaps[i], values));
+                        subs.add(new BinaryDocValuesSub(mergeState.docMaps[i], values, key));
                     }
                 }
             }


### PR DESCRIPTION
1. Copy SparseVector from old segment to segment instead of creating new to reduce double RAM peak usage
2. Change DocumentCluster's DocFreq to primitive array to reduce its memory footprint by 2/3.