### PR TITLE
dot product without boundary check

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/InMemorySparseVectorForwardIndex.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/InMemorySparseVectorForwardIndex.java
@@ -23,6 +23,8 @@ public class InMemorySparseVectorForwardIndex implements SparseVectorForwardInde
 
     private static final Map<InMemoryKey.IndexKey, InMemorySparseVectorForwardIndex> forwardIndexMap = new ConcurrentHashMap<>();
 
+    private static short maxDim;
+
     public static long memUsage() {
         long mem = 0;
         for (Map.Entry<InMemoryKey.IndexKey, InMemorySparseVectorForwardIndex> entry : forwardIndexMap.entrySet()) {
@@ -44,6 +46,10 @@ public class InMemorySparseVectorForwardIndex implements SparseVectorForwardInde
             throw new IllegalArgumentException("Index key cannot be null");
         }
         return forwardIndexMap.get(key);
+    }
+
+    public static short getMaxDimension() {
+        return maxDim;
     }
 
     public static void removeIndex(InMemoryKey.IndexKey key) {
@@ -96,6 +102,7 @@ public class InMemorySparseVectorForwardIndex implements SparseVectorForwardInde
         @Override
         public void write(int docId, SparseVector vector) {
             if (vector == null || docId >= sparseVectors.length) return;
+            maxDim = (maxDim > vector.getDimension()) ? maxDim : vector.getDimension();
             sparseVectors[docId] = vector;
         }
 

--- a/src/main/java/org/opensearch/neuralsearch/sparse/query/PostingWithClustersScorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/query/PostingWithClustersScorer.java
@@ -65,7 +65,7 @@ public class PostingWithClustersScorer extends Scorer {
         this.sparseQueryContext = sparseQueryContext;
         this.fieldName = fieldName;
         this.queryVector = queryVector;
-        this.queryDenseVector = queryVector.toDenseVector();
+        this.queryDenseVector = queryVector.toDenseVector(InMemorySparseVectorForwardIndex.getMaxDimension());
         this.visitedDocId = new LongBitSet(context.reader().maxDoc());
         this.acceptedDocs = acceptedDocs;
         this.reader = reader;
@@ -161,7 +161,7 @@ public class PostingWithClustersScorer extends Scorer {
                     if (doc == null) {
                         continue;
                     }
-                    score = doc.dotProduct(queryDenseVector);
+                    score = doc.dotProductAccelerated(queryDenseVector);
                     addToHeap(Pair.of(docId, score));
                     return docId;
                 }
@@ -216,7 +216,7 @@ public class PostingWithClustersScorer extends Scorer {
                         if (cluster.isShouldNotSkip()) {
                             return cluster;
                         }
-                        float score = cluster.getSummary().dotProduct(queryDenseVector);
+                        float score = cluster.getSummary().dotProductAccelerated(queryDenseVector);
                         if (scoreHeap.size() == sparseQueryContext.getK()
                             && score < scoreHeap.peek().getRight() / sparseQueryContext.getHeapFactor()) {
                             cluster = clusterIter.next();


### PR DESCRIPTION
### Description
I removed boundary checks inside dot product by making sure that the length of a DenseVector is always greater than the SparseVector.

However, this did not achieve latency performance improvement which happened in cpp side.
