### PR TITLE
Fix ram bytes used for document cluster

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/DocumentCluster.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/DocumentCluster.java
@@ -104,6 +104,9 @@ public class DocumentCluster implements Accountable {
             sizeInBytes += RamUsageEstimator.sizeOf(docIds);
             sizeInBytes += RamUsageEstimator.sizeOf(freqs);
         }
+        if (summary != null) {
+            sizeInBytes += summary.ramBytesUsed();
+        }
         return sizeInBytes;
     }
 


### PR DESCRIPTION
### Description
Fix ram bytes used for document cluster

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
