### PR TITLE
Change ClusteringTask to batch mode to avoid taking up high MEM usage

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/BatchClusteringTask.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/BatchClusteringTask.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.algorithm;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.neuralsearch.sparse.codec.InMemoryClusteredPosting;
+import org.opensearch.neuralsearch.sparse.codec.InMemorySparseVectorForwardIndex;
+import org.opensearch.neuralsearch.sparse.codec.SparsePostingsReader;
+import org.opensearch.neuralsearch.sparse.common.DocFreq;
+import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
+import org.opensearch.neuralsearch.sparse.common.SparseVector;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+@Log4j2
+public class BatchClusteringTask implements Supplier<List<Pair<BytesRef, PostingClusters>>> {
+    private final List<BytesRef> terms;
+    private final InMemoryKey.IndexKey key;
+    private final float alpha;
+    private final int beta;
+    private final int lambda;
+    private final MergeState mergeState;
+    private final FieldInfo fieldInfo;
+
+    public BatchClusteringTask(
+        List<BytesRef> terms,
+        InMemoryKey.IndexKey key,
+        float alpha,
+        int beta,
+        int lambda,
+        MergeState mergeState,
+        FieldInfo fieldInfo
+    ) {
+        this.terms = terms;
+        this.key = key;
+        this.alpha = alpha;
+        this.beta = beta;
+        this.lambda = lambda;
+        this.mergeState = mergeState;
+        this.fieldInfo = fieldInfo;
+    }
+
+    @Override
+    public List<Pair<BytesRef, PostingClusters>> get() {
+        List<Pair<BytesRef, PostingClusters>> postingClusters = new ArrayList<>();
+        try {
+            for (BytesRef term : this.terms) {
+                Map<Integer, Pair<Integer, InMemoryKey.IndexKey>> newToOldDocIdMap = new HashMap<>();
+                List<DocFreq> docFreqs = SparsePostingsReader.getMergedPostingForATerm(
+                    this.mergeState,
+                    term,
+                    this.fieldInfo,
+                    newToOldDocIdMap
+                );
+                PostingClustering postingClustering = new PostingClustering(
+                    lambda,
+                    new RandomClustering(lambda, alpha, beta, (newDocId) -> {
+                        Pair<Integer, InMemoryKey.IndexKey> oldDocId = newToOldDocIdMap.get(newDocId);
+                        if (oldDocId != null) {
+                            InMemorySparseVectorForwardIndex oldIndex = InMemorySparseVectorForwardIndex.get(oldDocId.getRight());
+                            if (oldIndex != null) {
+                                return oldIndex.getForwardIndexReader().readSparseVector(oldDocId.getLeft());
+                            }
+                        }
+                        InMemorySparseVectorForwardIndex newIndex = InMemorySparseVectorForwardIndex.get(this.key);
+                        if (newIndex != null) {
+                            SparseVector vector = newIndex.getForwardIndexReader().readSparseVector(newDocId);
+                            return vector;
+                        }
+                        return null;
+                    }),
+                    beta
+                );
+                List<DocumentCluster> clusters = postingClustering.cluster(docFreqs);
+                postingClusters.add(Pair.of(term, new PostingClusters(clusters)));
+                InMemoryClusteredPosting.InMemoryClusteredPostingWriter.writePostingClusters(key, term, clusters);
+            }
+        } catch (IOException e) {
+            log.error("cluster failed", e);
+            throw new RuntimeException(e);
+        }
+        return postingClusters;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsReader.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsReader.java
@@ -16,8 +16,8 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.neuralsearch.sparse.SparseTokensField;
+import org.opensearch.neuralsearch.sparse.algorithm.BatchClusteringTask;
 import org.opensearch.neuralsearch.sparse.algorithm.ClusterTrainingRunning;
-import org.opensearch.neuralsearch.sparse.algorithm.ClusteringTask;
 import org.opensearch.neuralsearch.sparse.algorithm.DocumentCluster;
 import org.opensearch.neuralsearch.sparse.algorithm.PostingClusters;
 import org.opensearch.neuralsearch.sparse.common.DocFreq;
@@ -28,7 +28,6 @@ import org.opensearch.neuralsearch.sparse.mapper.SparseMethodContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -82,39 +81,49 @@ public class SparsePostingsReader {
             sparseTermsLuceneWriter.writeTermsSize(allTerms.size());
             clusteredPostingTermsWriter.setFieldAndMaxDoc(fieldInfo, docCount);
 
-            List<CompletableFuture<PostingClusters>> futures = new ArrayList<>(allTerms.size());
-            for (BytesRef term : allTerms) {
-                Map<Integer, Pair<Integer, InMemoryKey.IndexKey>> newToOldDocIdMap = new HashMap<>();
-                List<DocFreq> docFreqs = getMergedPostingForATerm(term, fieldInfo, newToOldDocIdMap);
-                if (beta == 1) {
-                    // not run asynchronously
-                    futures.add(
-                        CompletableFuture.completedFuture(
-                            new ClusteringTask(term, docFreqs, key, alpha, beta, lambda, newToOldDocIdMap).get()
-                        )
-                    );
-                } else {
-                    futures.add(
-                        CompletableFuture.supplyAsync(
-                            new ClusteringTask(term, docFreqs, key, alpha, beta, lambda, newToOldDocIdMap),
-                            ClusterTrainingRunning.getInstance().getExecutor()
-                        )
-                    );
-                }
-            }
+            // this is a magic number which is effective
+            final int batchSize = 50;
+            List<CompletableFuture<List<Pair<BytesRef, PostingClusters>>>> futures = new ArrayList<>(
+                Math.round((float) allTerms.size() / batchSize)
+            );
             int i = 0;
+            List<BytesRef> termBatch = new ArrayList<>(batchSize);
             for (BytesRef term : allTerms) {
+                termBatch.add(term);
+                if (termBatch.size() == batchSize || i == allTerms.size() - 1) {
+                    if (beta == 1) {
+                        futures.add(
+                            CompletableFuture.completedFuture(
+                                new BatchClusteringTask(termBatch, key, alpha, beta, lambda, mergeState, fieldInfo).get()
+                            )
+                        );
+
+                    } else {
+                        futures.add(
+                            CompletableFuture.supplyAsync(
+                                new BatchClusteringTask(termBatch, key, alpha, beta, lambda, mergeState, fieldInfo),
+                                ClusterTrainingRunning.getInstance().getExecutor()
+                            )
+                        );
+                    }
+                    termBatch = new ArrayList<>(batchSize);
+                }
+                ++i;
+            }
+            for (int j = 0; j < futures.size(); ++j) {
                 try {
-                    PostingClusters cluster = futures.get(i).join();
-                    BlockTermState state = clusteredPostingTermsWriter.write(term, cluster);
-                    sparseTermsLuceneWriter.writeTerm(term, state);
+                    List<Pair<BytesRef, PostingClusters>> clusters = futures.get(j).join();
+                    futures.set(j, null);
+                    for (Pair<BytesRef, PostingClusters> p : clusters) {
+                        BlockTermState state = clusteredPostingTermsWriter.write(p.getLeft(), p.getRight());
+                        sparseTermsLuceneWriter.writeTerm(p.getLeft(), state);
+                    }
                 } catch (CancellationException | CompletionException ex) {
-                    log.error("Thread of running clustering from term {} during merge has exception", term, ex);
+                    log.error("Thread of running clustering from term {} during merge has exception", "", ex);
                 } catch (IOException ex) {
                     clusteredPostingTermsWriter.closeWithException();
                     sparseTermsLuceneWriter.closeWithException();
                 }
-                ++i;
             }
         }
     }
@@ -142,16 +151,17 @@ public class SparsePostingsReader {
         return allTerms;
     }
 
-    private List<DocFreq> getMergedPostingForATerm(
+    public static List<DocFreq> getMergedPostingForATerm(
+        MergeState mergeState,
         BytesRef term,
         FieldInfo fieldInfo,
         Map<Integer, Pair<Integer, InMemoryKey.IndexKey>> newToOldDocIdMap
     ) throws IOException {
         List<DocFreq> docFreqs = new ArrayList<>();
-        for (int i = 0; i < this.mergeState.fieldsProducers.length; i++) {
-            FieldsProducer fieldsProducer = this.mergeState.fieldsProducers[i];
+        for (int i = 0; i < mergeState.fieldsProducers.length; i++) {
+            FieldsProducer fieldsProducer = mergeState.fieldsProducers[i];
             // we need this SparseBinaryDocValuesPassThrough to get segment info
-            BinaryDocValues binaryDocValues = this.mergeState.docValuesProducers[i].getBinary(fieldInfo);
+            BinaryDocValues binaryDocValues = mergeState.docValuesProducers[i].getBinary(fieldInfo);
             if (!(binaryDocValues instanceof SparseBinaryDocValuesPassThrough)) {
                 log.error("binaryDocValues is not SparseBinaryDocValuesPassThrough, {}", binaryDocValues.getClass().getName());
                 continue;
@@ -190,7 +200,7 @@ public class SparsePostingsReader {
                         log.error("docId is -1");
                         continue;
                     }
-                    int newDocId = this.mergeState.docMaps[i].get(docIter.docID());
+                    int newDocId = mergeState.docMaps[i].get(docIter.docID());
                     if (newDocId == -1) {
                         continue;
                     }


### PR DESCRIPTION
Current solution, newToOldDocIdMap and docFreqs could be in memory for all terms. Change to batch clustering task to make them temporary variables and can be collected soon

on base_small, heap usage can be reduce by 30%-40%