### PR TITLE
Feat: Rescale document scores back to original float scale

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/ByteQuantizer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/ByteQuantizer.java
@@ -8,6 +8,20 @@ public final class ByteQuantizer {
 
     // The maximum float value to consider
     private static final float MAX_FLOAT_VALUE = 3.0f;
+    // Use full precision of byte (0-255)
+    private static final float MAX_UNSIGNED_BYTE_VALUE = 255.0f;
+    /**
+     * Rescaling factor to convert quantized dot product scores back to their original float scale.
+     * When vector components are quantized from float (0-3.0) to byte (0-255), dot products of these
+     * quantized vectors will have a different scale than the original float vectors. This constant
+     * provides the exact ratio needed to convert the quantized dot product back to the equivalent
+     * float dot product scale.
+     * Calculation: (MAX_FLOAT_VALUE²) / (MAX_UNSIGNED_BYTE_VALUE²)
+     * This represents the ratio between the square of the maximum float value (3.0²) and
+     * the square of the maximum byte value (255²), which is the scaling factor needed for
+     * dot products of quantized vectors.
+     */
+    public static final float SCORE_RESCALE_RATIO = MAX_FLOAT_VALUE * MAX_FLOAT_VALUE / MAX_UNSIGNED_BYTE_VALUE / MAX_UNSIGNED_BYTE_VALUE;
 
     private ByteQuantizer() {} // no instance of this utility class
 
@@ -23,7 +37,7 @@ public final class ByteQuantizer {
 
         // Scale the value to fit in the byte range (0-255)
         // Note: In Java, byte is signed (-128 to 127), but we'll use the full precision
-        value = (value * 255.0f) / MAX_FLOAT_VALUE;
+        value = (value * MAX_UNSIGNED_BYTE_VALUE) / MAX_FLOAT_VALUE;
 
         // Round to nearest integer and cast to byte
         return (byte) Math.round(value);

--- a/src/main/java/org/opensearch/neuralsearch/sparse/query/PostingWithClustersScorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/query/PostingWithClustersScorer.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.PriorityQueue;
 
+import static org.opensearch.neuralsearch.sparse.algorithm.ByteQuantizer.SCORE_RESCALE_RATIO;
+
 /**
  * A scorer that simulates the query algorithm in seismic.
  * For each query token: we get its posting with clusters. We compute score = dp(cluster_summary, query) and
@@ -200,7 +202,7 @@ public class PostingWithClustersScorer extends Scorer {
 
     @Override
     public float score() throws IOException {
-        return score;
+        return score * SCORE_RESCALE_RATIO;
     }
 
     class SingleScorer extends Scorer {


### PR DESCRIPTION
### Description
Rescale document scores back to original float scale

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
