### PR TITLE
Fix: query serialization and deserialization of multi-node cluster

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/query/SparseAnnQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/query/SparseAnnQueryBuilder.java
@@ -109,8 +109,12 @@ public class SparseAnnQueryBuilder extends AbstractQueryBuilder<SparseAnnQueryBu
             Map<String, Float> queryTokens = in.readMap(StreamInput::readString, StreamInput::readFloat);
             this.queryTokensSupplier = () -> queryTokens;
         }
-        // to be backward compatible with previous version, we need to use writeString/readString API instead of optionalString API
-        // after supporting query by tokens, queryText and modelId can be null. here we write an empty String instead
+        // Add these lines to read the missing parameters
+        this.queryCut = in.readOptionalInt();
+        this.k = in.readOptionalInt();
+        this.heapFactor = in.readOptionalFloat();
+
+        // Existing code for backward compatibility
         if (StringUtils.EMPTY.equals(this.queryText)) {
             this.queryText = null;
         }
@@ -122,8 +126,6 @@ public class SparseAnnQueryBuilder extends AbstractQueryBuilder<SparseAnnQueryBu
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeString(this.fieldName);
-        // to be backward compatible with previous version, we need to use writeString/readString API instead of optionalString API
-        // after supporting query by tokens, queryText and modelId can be null. here we write an empty String instead
         out.writeString(StringUtils.defaultString(this.queryText, StringUtils.EMPTY));
         if (isClusterOnOrAfterMinReqVersionForDefaultModelIdSupport()) {
             out.writeOptionalString(this.modelId);
@@ -136,6 +138,9 @@ public class SparseAnnQueryBuilder extends AbstractQueryBuilder<SparseAnnQueryBu
         } else {
             out.writeBoolean(false);
         }
+        out.writeOptionalInt(this.queryCut);
+        out.writeOptionalInt(this.k);
+        out.writeOptionalFloat(this.heapFactor);
     }
 
     @Override


### PR DESCRIPTION
### Description
This PR fixes the bug for sparse ann query serialization and deserialization. Now, query_cut, k and heap_factor can be parsed correctly for the rest nodes in the OpenSearch cluster.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
