### PR TITLE
Remove Lambda from The Input List

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/Seismic.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/Seismic.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.ALGO_TRIGGER_DOC_COUNT_FIELD;
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SUMMARY_PRUNE_RATIO_FIELD;
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.CLUSTER_RATIO_FIELD;
-import static org.opensearch.neuralsearch.sparse.common.SparseConstants.N_POSTINGS_FIELD;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Seismic implements SparseAlgorithm {
@@ -40,13 +39,6 @@ public class Seismic implements SparseAlgorithm {
                 errorMessages.add("summary prune ratio should be in (0, 1]");
             }
             parameters.remove(SUMMARY_PRUNE_RATIO_FIELD);
-        }
-        if (parameters.containsKey(N_POSTINGS_FIELD)) {
-            Integer nPostings = (Integer) parameters.get(N_POSTINGS_FIELD);
-            if (nPostings <= 0) {
-                errorMessages.add("n_postings should be a positive integer");
-            }
-            parameters.remove(N_POSTINGS_FIELD);
         }
         if (parameters.containsKey(CLUSTER_RATIO_FIELD)) {
             float clusterRatio = ((Number) parameters.get(CLUSTER_RATIO_FIELD)).floatValue();

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriter.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriter.java
@@ -40,7 +40,8 @@ import org.opensearch.neuralsearch.sparse.algorithm.ByteQuantizer;
 
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SUMMARY_PRUNE_RATIO_FIELD;
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.CLUSTER_RATIO_FIELD;
-import static org.opensearch.neuralsearch.sparse.common.SparseConstants.N_POSTINGS_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.Seismic.DEFAULT_POSTING_PRUNE_RATIO;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.Seismic.DEFAULT_POSTING_MINIMUM_LENGTH;
 
 /**
  * ClusteredPostingTermsWriter is used to write postings for each segment.
@@ -82,7 +83,7 @@ public class ClusteredPostingTermsWriter extends PushPostingsWriterBase {
         SparseVectorForwardIndex index = InMemorySparseVectorForwardIndex.getOrCreate(key, maxDoc);
         assert (index != null);
         float cluster_ratio = Float.parseFloat(fieldInfo.attributes().get(CLUSTER_RATIO_FIELD));
-        int nPostings = Integer.parseInt(fieldInfo.attributes().get(N_POSTINGS_FIELD));
+        int nPostings = Math.max((int) (DEFAULT_POSTING_PRUNE_RATIO * maxDoc), DEFAULT_POSTING_MINIMUM_LENGTH);
         float summaryPruneRatio = Float.parseFloat(fieldInfo.attributes().get(SUMMARY_PRUNE_RATIO_FIELD));
         this.postingClustering = new PostingClustering(
             nPostings,

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsReader.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsReader.java
@@ -37,7 +37,8 @@ import java.util.concurrent.CompletionException;
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.ALGO_TRIGGER_DOC_COUNT_FIELD;
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SUMMARY_PRUNE_RATIO_FIELD;
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.CLUSTER_RATIO_FIELD;
-import static org.opensearch.neuralsearch.sparse.common.SparseConstants.N_POSTINGS_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.Seismic.DEFAULT_POSTING_PRUNE_RATIO;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.Seismic.DEFAULT_POSTING_MINIMUM_LENGTH;
 
 /**
  * Merge sparse postings
@@ -74,7 +75,7 @@ public class SparsePostingsReader {
 
             InMemoryKey.IndexKey key = new InMemoryKey.IndexKey(mergeState.segmentInfo, fieldInfo);
             float clusterRatio = Float.parseFloat(fieldInfo.attributes().get(CLUSTER_RATIO_FIELD));
-            int nPostings = Integer.parseInt(fieldInfo.attributes().get(N_POSTINGS_FIELD));
+            int nPostings = Math.max((int) (DEFAULT_POSTING_PRUNE_RATIO * docCount), DEFAULT_POSTING_MINIMUM_LENGTH);
             float summaryPruneRatio = Float.parseFloat(fieldInfo.attributes().get(SUMMARY_PRUNE_RATIO_FIELD));
             int clusterUtilDocCountReach = Integer.parseInt(fieldInfo.attributes().get(ALGO_TRIGGER_DOC_COUNT_FIELD));
 

--- a/src/main/java/org/opensearch/neuralsearch/sparse/common/SparseConstants.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/common/SparseConstants.java
@@ -7,16 +7,16 @@ package org.opensearch.neuralsearch.sparse.common;
 public final class SparseConstants {
     public static final String NAME_FIELD = "name";
     public static final String PARAMETERS_FIELD = "parameters";
-    public static final String N_POSTINGS_FIELD = "n_postings";
     public static final String SUMMARY_PRUNE_RATIO_FIELD = "summary_prune_ratio";
     public static final String SEISMIC = "seismic";
     public static final String CLUSTER_RATIO_FIELD = "cluster_ratio";
     public static final String ALGO_TRIGGER_DOC_COUNT_FIELD = "algo_trigger_doc_count";
 
     public final class Seismic {
-        public static final int DEFAULT_N_POSTINGS = 6000;
         public static final float DEFAULT_SUMMARY_PRUNE_RATIO = 0.4f;
         public static final float DEFAULT_CLUSTER_RATIO = 0.1f;
         public static final int DEFAULT_ALGO_TRIGGER_DOC_COUNT = 1000000;
+        public static final float DEFAULT_POSTING_PRUNE_RATIO = 0.0005f;
+        public static final int DEFAULT_POSTING_MINIMUM_LENGTH = 160;
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldMapper.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldMapper.java
@@ -34,9 +34,7 @@ import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SUMMARY_
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.CLUSTER_RATIO_FIELD;
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.Seismic.DEFAULT_SUMMARY_PRUNE_RATIO;
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.Seismic.DEFAULT_CLUSTER_RATIO;
-import static org.opensearch.neuralsearch.sparse.common.SparseConstants.Seismic.DEFAULT_N_POSTINGS;
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.Seismic.DEFAULT_ALGO_TRIGGER_DOC_COUNT;
-import static org.opensearch.neuralsearch.sparse.common.SparseConstants.N_POSTINGS_FIELD;
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SEISMIC;
 
 /**
@@ -208,14 +206,11 @@ public class SparseTokensFieldMapper extends ParametrizedFieldMapper {
 
     private void setFieldTypeAttributes(FieldType fieldType, SparseMethodContext sparseMethodContext) {
         if (sparseMethodContext.getName().equals(SEISMIC)) {
-            Integer nPostings = (Integer) sparseMethodContext.getMethodComponentContext()
-                .getParameter(N_POSTINGS_FIELD, DEFAULT_N_POSTINGS);
             Float clusterRatio = sparseMethodContext.getMethodComponentContext().getFloat(CLUSTER_RATIO_FIELD, DEFAULT_CLUSTER_RATIO);
             Float summaryPruneRatio = sparseMethodContext.getMethodComponentContext()
                 .getFloat(SUMMARY_PRUNE_RATIO_FIELD, DEFAULT_SUMMARY_PRUNE_RATIO);
             Integer algoTriggerThreshold = (Integer) sparseMethodContext.getMethodComponentContext()
                 .getParameter(ALGO_TRIGGER_DOC_COUNT_FIELD, DEFAULT_ALGO_TRIGGER_DOC_COUNT);
-            fieldType.putAttribute(N_POSTINGS_FIELD, String.valueOf(nPostings));
             fieldType.putAttribute(SUMMARY_PRUNE_RATIO_FIELD, String.valueOf(summaryPruneRatio));
             fieldType.putAttribute(CLUSTER_RATIO_FIELD, String.valueOf(clusterRatio));
             fieldType.putAttribute(ALGO_TRIGGER_DOC_COUNT_FIELD, String.valueOf(algoTriggerThreshold));


### PR DESCRIPTION
### Description
In this PR, I removed `nPostings` (or `lambda`) from the input list. A user does not need to give a specific value of how long he or she wants to keep a posting list. Instead, we will calculate a proper posting list length for users by the following equation:
$\text{nPostings} = \text{Max}(0.0005 * \text{Number of Documents}, 160)$.
We choose 160 as a minimum posting prune length because it fits well with 100K documents, and we would only suggest users using SEISMIC once their dataset size reaches 100K.
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
