### PR TITLE
Feat: read sparse vector from disk if it is not within memory

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/InMemorySparseVectorForwardIndex.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/InMemorySparseVectorForwardIndex.java
@@ -11,6 +11,7 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 import org.opensearch.neuralsearch.sparse.common.SparseVector;
 import org.opensearch.neuralsearch.sparse.common.SparseVectorReader;
+import org.opensearch.neuralsearch.sparse.common.SparseVectorWriter;
 
 import java.io.IOException;
 import java.util.Map;

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
@@ -19,6 +19,7 @@ import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 import org.opensearch.neuralsearch.sparse.common.MergeHelper;
 import org.opensearch.neuralsearch.sparse.common.PredicateUtils;
 import org.opensearch.neuralsearch.sparse.common.SparseVector;
+import org.opensearch.neuralsearch.sparse.common.SparseVectorWriter;
 
 import java.io.IOException;
 
@@ -58,7 +59,7 @@ public class SparseDocValuesConsumer extends DocValuesConsumer {
         BinaryDocValues binaryDocValues = valuesProducer.getBinary(field);
         InMemoryKey.IndexKey key = new InMemoryKey.IndexKey(this.state.segmentInfo, field);
         int docCount = this.state.segmentInfo.maxDoc();
-        SparseVectorForwardIndex.SparseVectorWriter writer = InMemorySparseVectorForwardIndex.getOrCreate(key, docCount).getWriter();
+        SparseVectorWriter writer = InMemorySparseVectorForwardIndex.getOrCreate(key, docCount).getWriter();
         if (writer == null) {
             throw new IllegalStateException("Forward index writer is null");
         }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseVectorForwardIndex.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseVectorForwardIndex.java
@@ -4,12 +4,9 @@
  */
 package org.opensearch.neuralsearch.sparse.codec;
 
-import org.apache.lucene.util.BytesRef;
 import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
-import org.opensearch.neuralsearch.sparse.common.SparseVector;
 import org.opensearch.neuralsearch.sparse.common.SparseVectorReader;
-
-import java.io.IOException;
+import org.opensearch.neuralsearch.sparse.common.SparseVectorWriter;
 
 /**
  * Interface for sparse vector forward index
@@ -18,12 +15,6 @@ public interface SparseVectorForwardIndex {
     SparseVectorReader getReader();  // covariant return type
 
     SparseVectorWriter getWriter();  // covariant return type
-
-    interface SparseVectorWriter {
-        void write(int docId, SparseVector vector) throws IOException;
-
-        void write(int docId, BytesRef data) throws IOException;
-    }
 
     static void removeIndex(InMemoryKey.IndexKey key) {
         InMemorySparseVectorForwardIndex.removeIndex(key);

--- a/src/main/java/org/opensearch/neuralsearch/sparse/common/SparseVectorWriter.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/common/SparseVectorWriter.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.common;
+
+import org.apache.lucene.util.BytesRef;
+
+import java.io.IOException;
+
+public interface SparseVectorWriter {
+    void write(int docId, SparseVector vector) throws IOException;
+
+    void write(int docId, BytesRef data) throws IOException;
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/query/SparseQueryWeight.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/query/SparseQueryWeight.java
@@ -5,6 +5,7 @@
 package org.opensearch.neuralsearch.sparse.query;
 
 import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FilterCodecReader;
 import org.apache.lucene.index.FilterLeafReader;
@@ -27,10 +28,13 @@ import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.Bits;
 import org.opensearch.neuralsearch.sparse.algorithm.ByteQuantizer;
 import org.opensearch.neuralsearch.sparse.codec.InMemorySparseVectorForwardIndex;
+import org.opensearch.neuralsearch.sparse.codec.SparseBinaryDocValuesPassThrough;
 import org.opensearch.neuralsearch.sparse.codec.SparseVectorForwardIndex;
 import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 import org.opensearch.neuralsearch.sparse.common.PredicateUtils;
+import org.opensearch.neuralsearch.sparse.common.SparseVector;
 import org.opensearch.neuralsearch.sparse.common.SparseVectorReader;
+import org.opensearch.neuralsearch.sparse.common.SparseVectorWriter;
 
 import java.io.IOException;
 
@@ -122,9 +126,10 @@ public class SparseQueryWeight extends Weight {
         if (segmentInfo != null) {
             InMemoryKey.IndexKey key = new InMemoryKey.IndexKey(segmentInfo, fieldType);
             SparseVectorForwardIndex index = InMemorySparseVectorForwardIndex.get(key);
-            if (index != null) {
-                sparseReader = index.getReader();
+            if (index == null) {
+                InMemorySparseVectorForwardIndex.getOrCreate(key, segmentInfo.maxDoc());
             }
+            sparseReader = getSparseVectorReader(context.reader(), query.getFieldName());
         }
         Similarity.SimScorer simScorer = ByteQuantizer.getSimScorer(boost);
         BitSetIterator filterBitIterator = null;
@@ -148,6 +153,33 @@ public class SparseQueryWeight extends Weight {
             simScorer,
             filterBitIterator
         );
+    }
+
+    private SparseVectorReader getSparseVectorReader(LeafReader leafReader, String fieldName) throws IOException {
+        BinaryDocValues docValues = leafReader.getBinaryDocValues(fieldName);
+        if (docValues instanceof SparseBinaryDocValuesPassThrough sparseBinaryDocValuesPassThrough) {
+            SparseVectorReader reader;
+            SegmentInfo segmentInfo = sparseBinaryDocValuesPassThrough.getSegmentInfo();
+            InMemoryKey.IndexKey key = new InMemoryKey.IndexKey(segmentInfo, fieldName);
+            SparseVectorForwardIndex index = InMemorySparseVectorForwardIndex.get(key);
+            if (index != null) {
+                SparseVectorReader inMemoryReader = index.getReader();
+                SparseVectorWriter inMemoryWriter = index.getWriter();
+                reader = (docId) -> {
+                    SparseVector vector = inMemoryReader.read(docId);
+                    if (vector != null) {
+                        return vector;
+                    }
+                    vector = sparseBinaryDocValuesPassThrough.read(docId);
+                    inMemoryWriter.write(docId, vector);
+                    return vector;
+                };
+            } else {
+                reader = sparseBinaryDocValuesPassThrough;
+            }
+            return reader;
+        }
+        return (docId) -> null;
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/sparse/query/SparseQueryWeight.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/query/SparseQueryWeight.java
@@ -122,7 +122,9 @@ public class SparseQueryWeight extends Weight {
         if (segmentInfo != null) {
             InMemoryKey.IndexKey key = new InMemoryKey.IndexKey(segmentInfo, fieldType);
             SparseVectorForwardIndex index = InMemorySparseVectorForwardIndex.get(key);
-            sparseReader = index != null ? index.getReader() : (docId -> { return null; });
+            if (index != null) {
+                sparseReader = index.getReader();
+            }
         }
         Similarity.SimScorer simScorer = ByteQuantizer.getSimScorer(boost);
         BitSetIterator filterBitIterator = null;


### PR DESCRIPTION
### Description
With this PR, Seismic scorer can read the sparse vector from disk if it is not within the memory. Warming up the index is no longer a P0 for 3.2.0 release

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
