### PR TITLE
[Unit Tests] Mapper and Algorithm

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseTokensFieldTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseTokensFieldTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse;
+
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexableFieldType;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.opensearch.neuralsearch.sparse.SparseTokensField.SPARSE_FIELD;
+
+public class SparseTokensFieldTests extends AbstractSparseTestBase {
+
+    private final String fieldName = "testField";
+    private final byte[] testValue = new byte[] { 1, 2, 3 };
+    private final IndexableFieldType mockType = testsPrepareUtils.prepareMockIndexableFieldType();
+
+    public void testSparseTokensFieldConstructor() {
+        SparseTokensField field = new SparseTokensField(fieldName, testValue, mockType);
+
+        assertNotNull("Field should be created successfully", field);
+        assertEquals("Field name should match", fieldName, field.name());
+        assertArrayEquals("Binary value should match", testValue, field.binaryValue().bytes);
+        assertEquals("Field type should match", mockType, field.fieldType());
+    }
+
+    public void testIsSparseFieldReturnsFalseWhenFieldIsNull() {
+        FieldInfo field = null;
+        assertFalse("Should return false for null field", SparseTokensField.isSparseField(field));
+    }
+
+    public void testIsSparseFieldWhenFieldContainsSparseAttribute() throws Exception {
+        testsPrepareUtils prepareHelper = new testsPrepareUtils();
+        FieldInfo mockField = prepareHelper.prepareKeyFieldInfo();
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(SPARSE_FIELD, "true");
+
+        Field attributesField = FieldInfo.class.getDeclaredField("attributes");
+        attributesField.setAccessible(true);
+        attributesField.set(mockField, attributes);
+
+        boolean result = SparseTokensField.isSparseField(mockField);
+
+        assertTrue("Should return true for field with sparse attribute", result);
+    }
+
+    public void testIsSparseFieldWithNullField() {
+        assertFalse("Should return false for null field", SparseTokensField.isSparseField(null));
+    }
+
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/BatchClusteringTaskTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/BatchClusteringTaskTests.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.algorithm;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.util.BytesRef;
+import org.junit.Before;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
+import org.opensearch.neuralsearch.sparse.testsPrepareUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.lang.reflect.Field;
+
+public class BatchClusteringTaskTests extends AbstractSparseTestBase {
+    private List<BytesRef> terms;
+    private InMemoryKey.IndexKey key;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        terms = Arrays.asList(new BytesRef("term1"), new BytesRef("term2"));
+        key = new InMemoryKey.IndexKey(null, "test_field");
+    }
+
+    public void testConstructorDeepCopiesTerms() throws Exception {
+        // Setup
+        List<BytesRef> originalTerms = Arrays.asList(new BytesRef("term1"), new BytesRef("term2"));
+
+        // Execute - create task with null mergeState to test constructor
+        BatchClusteringTask task = new BatchClusteringTask(originalTerms, key, 0.5f, 0.3f, 10, null, null);
+
+        // Verify task is created
+        assertNotNull("Task should be created successfully", task);
+
+        Field termsField = BatchClusteringTask.class.getDeclaredField("terms");
+        termsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        List<BytesRef> taskTerms = (List<BytesRef>) termsField.get(task);
+
+        // Verify deep copy by checking actual content
+        assertEquals("First term should be 'term1'", "term1", taskTerms.get(0).utf8ToString());
+
+        // Modify original terms to verify deep copy
+        originalTerms.get(0).bytes[0] = (byte) 'X';
+
+        // Verify task's terms remain unchanged (proving deep copy worked)
+        assertEquals("Task's first term should still be 'term1'", "term1", taskTerms.get(0).utf8ToString());
+        assertNotEquals("Original term should now be different", "term1", originalTerms.get(0).utf8ToString());
+    }
+
+    public void testTaskCreationWithDifferentParameters() throws Exception {
+        // Test creating tasks with different parameter combinations
+        float[] summaryPruneRatios = { 0.1f, 0.5f, 0.9f };
+        float[] clusterRatios = { 0.0f, 0.3f, 1.0f };
+        int[] nPostingsValues = { 1, 10, 100 };
+
+        for (float summaryPruneRatio : summaryPruneRatios) {
+            for (float clusterRatio : clusterRatios) {
+                for (int nPostings : nPostingsValues) {
+                    BatchClusteringTask task = new BatchClusteringTask(terms, key, summaryPruneRatio, clusterRatio, nPostings, null, null);
+                    assertNotNull(
+                            "Task should be created with parameters: " + summaryPruneRatio + ", " + clusterRatio + ", " + nPostings,
+                            task
+                    );
+                }
+            }
+        }
+    }
+
+    public void testGetWithNullMergeState() throws Exception {
+        // Test behavior with null merge state - should throw NullPointerException when accessing maxDocs
+        BatchClusteringTask task = new BatchClusteringTask(terms, key, 0.5f, 0.3f, 10, null, null);
+
+        Exception exception = assertThrows(NullPointerException.class, () -> task.get());
+
+        // Assert that the exception is an instance of NullPointerException
+        assertTrue("Exception should be an instance of NullPointerException", exception instanceof NullPointerException);
+    }
+
+    public void testGetWithNonNullMergeState() throws Exception {
+        // Test behavior with a not null merge state
+        boolean isEmptyMaxDocs = false;
+        testsPrepareUtils prepareHelper = new testsPrepareUtils();
+        MergeState mergeState = prepareHelper.prepareMergeState(isEmptyMaxDocs);
+        FieldInfo keyFieldInfo = prepareHelper.prepareKeyFieldInfo();
+
+        // Create BatchClusteringTask
+        BatchClusteringTask task = new BatchClusteringTask(terms, key, 0.5f, 0.3f, 10, mergeState, keyFieldInfo);
+
+        // Execute and examine the result
+        List<Pair<BytesRef, PostingClusters>> result = task.get();
+
+        // Verify the returned clusters
+        assertNotNull("Result should not be null", result);
+        System.out.println("Result: " + result);
+        assertEquals("Should return clusters for each term", terms.size(), result.size());
+
+        for (int i = 0; i < result.size(); i++) {
+            Pair<BytesRef, PostingClusters> pair = result.get(i);
+
+            // Verify term matches
+            assertNotNull("Term should not be null", pair.getLeft());
+            assertEquals("Term should match input", terms.get(i).utf8ToString(), pair.getLeft().utf8ToString());
+
+            // Verify clusters
+            PostingClusters clusters = pair.getRight();
+            assertNotNull("PostingClusters should not be null", clusters);
+            assertNotNull("Clusters list should not be null", clusters.getClusters());
+
+            // Additional cluster validation
+            assertTrue("Should have non-negative cluster count", clusters.getClusters().size() >= 0);
+        }
+    }
+
+    public void testGetWithNonNullMergeStateZeroMaxDocs() throws Exception {
+        // Test behavior with a not null merge state
+        boolean isEmptyMaxDocs = true;
+        testsPrepareUtils prepareHelper = new testsPrepareUtils();
+        MergeState mergeState = prepareHelper.prepareMergeState(isEmptyMaxDocs);
+        FieldInfo keyFieldInfo = prepareHelper.prepareKeyFieldInfo();
+
+        // Create BatchClusteringTask
+        BatchClusteringTask task = new BatchClusteringTask(terms, key, 0.5f, 0.3f, 10, mergeState, keyFieldInfo);
+
+        // Execute and examine the result
+        List<Pair<BytesRef, PostingClusters>> result = task.get();
+
+        // Verify the returned clusters
+        assertNotNull("Result should not be null", result);
+        // Should trigger early quit schema to return an empty list
+        assertEquals("Should return an empty list", 0, result.size());
+    }
+
+    public void testTermsDeepCopyInGet() throws Exception {
+        // Test that the terms are properly deep copied and used in get() method
+        List<BytesRef> originalTerms = Arrays.asList(new BytesRef("original1"), new BytesRef("original2"));
+
+        BatchClusteringTask task = new BatchClusteringTask(originalTerms, key, 0.5f, 0.3f, 10, null, null);
+
+        // Modify original terms
+        originalTerms.get(0).bytes[0] = (byte) 'M';
+
+        // The task should still have the original values due to deep copy
+        // We can't easily test the get() method output, but we can verify the task was created properly
+        assertNotNull("Task should be created and maintain its own copy of terms", task);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/ClusterTrainingRunningTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/ClusterTrainingRunningTests.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.algorithm;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import org.junit.Before;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.threadpool.ThreadPool;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+public class ClusterTrainingRunningTests extends AbstractSparseTestBase {
+    private ThreadPool threadPool;
+    private ExecutorService executorService;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        threadPool = mock(ThreadPool.class);
+        executorService = mock(ExecutorService.class);
+        when(threadPool.executor(ClusterTrainingRunning.THREAD_POOL_NAME)).thenReturn(executorService);
+    }
+
+    public void testInitialize_setsThreadPool() {
+        ClusterTrainingRunning.initialize(threadPool);
+
+        ClusterTrainingRunning instance = ClusterTrainingRunning.getInstance();
+        assertNotNull(instance);
+    }
+
+    public void testGetInstance_returnsSameInstance() {
+        ClusterTrainingRunning instance1 = ClusterTrainingRunning.getInstance();
+        ClusterTrainingRunning instance2 = ClusterTrainingRunning.getInstance();
+
+        assertNotNull(instance1);
+        assertNotNull(instance2);
+        assertSame(instance1, instance2);
+    }
+
+    public void testGetExecutor_returnsCorrectExecutor() {
+        ClusterTrainingRunning.initialize(threadPool);
+        ClusterTrainingRunning instance = ClusterTrainingRunning.getInstance();
+
+        ExecutorService result = (ExecutorService) instance.getExecutor();
+
+        assertEquals(executorService, result);
+        verify(threadPool, times(1)).executor(ClusterTrainingRunning.THREAD_POOL_NAME);
+    }
+
+    public void testRun_executesRunnable() {
+        ClusterTrainingRunning.initialize(threadPool);
+        ClusterTrainingRunning instance = ClusterTrainingRunning.getInstance();
+        Runnable runnable = mock(Runnable.class);
+
+        instance.run(runnable);
+
+        verify(threadPool, times(1)).executor(ClusterTrainingRunning.THREAD_POOL_NAME);
+        verify(executorService, times(1)).execute(runnable);
+    }
+
+    public void testSubmit_returnsCorrectFuture() {
+        ClusterTrainingRunning.initialize(threadPool);
+        ClusterTrainingRunning instance = ClusterTrainingRunning.getInstance();
+        Callable<String> callable = () -> "test result";
+        Future<String> expectedFuture = mock(Future.class);
+        when(executorService.submit(callable)).thenReturn(expectedFuture);
+
+        Future<String> result = instance.submit(callable);
+
+        assertEquals(expectedFuture, result);
+        verify(threadPool, times(1)).executor(ClusterTrainingRunning.THREAD_POOL_NAME);
+        verify(executorService, times(1)).submit(callable);
+    }
+
+    public void testSubmit_withDifferentCallableTypes() {
+        ClusterTrainingRunning.initialize(threadPool);
+        ClusterTrainingRunning instance = ClusterTrainingRunning.getInstance();
+
+        // Test with Integer callable
+        Callable<Integer> intCallable = () -> 42;
+        Future<Integer> intFuture = mock(Future.class);
+        when(executorService.submit(intCallable)).thenReturn(intFuture);
+
+        Future<Integer> intResult = instance.submit(intCallable);
+
+        assertEquals(intFuture, intResult);
+        verify(executorService, times(1)).submit(intCallable);
+    }
+
+    public void testThreadPoolName_hasCorrectValue() {
+        assertEquals("cluster_training_thread_pool", ClusterTrainingRunning.THREAD_POOL_NAME);
+    }
+
+    public void testMultipleRuns_callsExecutorMultipleTimes() {
+        ClusterTrainingRunning.initialize(threadPool);
+        ClusterTrainingRunning instance = ClusterTrainingRunning.getInstance();
+        Runnable runnable1 = mock(Runnable.class);
+        Runnable runnable2 = mock(Runnable.class);
+
+        instance.run(runnable1);
+        instance.run(runnable2);
+
+        verify(threadPool, times(2)).executor(ClusterTrainingRunning.THREAD_POOL_NAME);
+        verify(executorService, times(1)).execute(runnable1);
+        verify(executorService, times(1)).execute(runnable2);
+    }
+
+    public void testGetExecutor_afterInitialization_returnsValidExecutor() {
+        ClusterTrainingRunning.initialize(threadPool);
+        ClusterTrainingRunning instance = ClusterTrainingRunning.getInstance();
+
+        ExecutorService executor1 = (ExecutorService) instance.getExecutor();
+        ExecutorService executor2 = (ExecutorService) instance.getExecutor();
+
+        assertNotNull(executor1);
+        assertNotNull(executor2);
+        assertEquals(executor1, executor2);
+        verify(threadPool, times(2)).executor(ClusterTrainingRunning.THREAD_POOL_NAME);
+    }
+
+    public void testSubmit_withNullCallable_passesToExecutor() {
+        ClusterTrainingRunning.initialize(threadPool);
+        ClusterTrainingRunning instance = ClusterTrainingRunning.getInstance();
+
+        instance.submit(null);
+
+        verify(threadPool, times(1)).executor(ClusterTrainingRunning.THREAD_POOL_NAME);
+        verify(executorService, times(1)).submit((Callable<Object>) null);
+    }
+
+    public void testRun_withNullRunnable_passesToExecutor() {
+        ClusterTrainingRunning.initialize(threadPool);
+        ClusterTrainingRunning instance = ClusterTrainingRunning.getInstance();
+
+        instance.run(null);
+
+        verify(threadPool, times(1)).executor(ClusterTrainingRunning.THREAD_POOL_NAME);
+        verify(executorService, times(1)).execute(null);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/ClusteringTaskTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/ClusteringTaskTests.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.algorithm;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.lucene.util.BytesRef;
+import org.junit.Before;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.common.DocFreq;
+import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.doThrow;
+
+public class ClusteringTaskTests extends AbstractSparseTestBase {
+    private BytesRef term;
+    private List<DocFreq> docs;
+    private InMemoryKey.IndexKey key;
+    private PostingClustering postingClustering;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        term = new BytesRef("test_term");
+        key = mock(InMemoryKey.IndexKey.class);
+        docs = Arrays.asList(new DocFreq(1, (byte) 1), new DocFreq(2, (byte) 2));
+        postingClustering = mock(PostingClustering.class);
+    }
+
+    public void testConstructor_withValidInputs_createsTask() {
+
+        ClusteringTask task = new ClusteringTask(term, docs, key, postingClustering);
+
+        assertNotNull(task);
+    }
+
+    public void testConstructor_withEmptyDocs_createsTask() {
+        docs = Collections.emptyList();
+
+        ClusteringTask task = new ClusteringTask(term, docs, key, postingClustering);
+
+        assertNotNull(task);
+    }
+
+    public void testGet_withValidClustering_returnsPostingClusters() throws IOException {
+        List<DocumentCluster> expectedClusters = Arrays.asList(mock(DocumentCluster.class), mock(DocumentCluster.class));
+        when(postingClustering.cluster(any())).thenReturn(expectedClusters);
+
+        ClusteringTask task = new ClusteringTask(term, docs, key, postingClustering);
+        PostingClusters result = task.get();
+
+        assertNotNull(result);
+        assertNotNull(result.getClusters());
+        assertEquals(2, result.getClusters().size());
+        verify(postingClustering, times(1)).cluster(any());
+    }
+
+    public void testGet_withEmptyDocs_returnsPostingClusters() throws IOException {
+        docs = Collections.emptyList();
+
+        List<DocumentCluster> expectedClusters = Collections.emptyList();
+        when(postingClustering.cluster(any())).thenReturn(expectedClusters);
+
+        ClusteringTask task = new ClusteringTask(term, docs, key, postingClustering);
+        PostingClusters result = task.get();
+
+        assertNotNull(result);
+        assertNotNull(result.getClusters());
+        assertEquals(0, result.getClusters().size());
+        verify(postingClustering, times(1)).cluster(any());
+    }
+
+    public void testGet_withIOException_throwsRuntimeException() throws IOException {
+        doThrow(new IOException("Test exception")).when(postingClustering).cluster(any());
+
+        ClusteringTask task = new ClusteringTask(term, docs, key, postingClustering);
+
+        try {
+            task.get();
+            fail("Expected RuntimeException to be thrown");
+        } catch (RuntimeException e) {
+            assertTrue(e.getCause() instanceof IOException);
+            assertEquals("Test exception", e.getCause().getMessage());
+        }
+    }
+
+    public void testGet_callsClusteringWithCorrectDocs() throws IOException {
+        docs = Arrays.asList(new DocFreq(1, (byte) 1), new DocFreq(2, (byte) 2), new DocFreq(3, (byte) 3));
+
+        List<DocumentCluster> expectedClusters = Arrays.asList(mock(DocumentCluster.class));
+        when(postingClustering.cluster(any())).thenReturn(expectedClusters);
+
+        ClusteringTask task = new ClusteringTask(term, docs, key, postingClustering);
+        task.get();
+
+        verify(postingClustering, times(1)).cluster(docs);
+    }
+
+    public void testGet_withSingleDoc_returnsPostingClusters() throws IOException {
+        docs = Arrays.asList(new DocFreq(42, (byte) 5));
+
+        List<DocumentCluster> expectedClusters = Arrays.asList(mock(DocumentCluster.class));
+        when(postingClustering.cluster(any())).thenReturn(expectedClusters);
+
+        ClusteringTask task = new ClusteringTask(term, docs, key, postingClustering);
+        PostingClusters result = task.get();
+
+        assertNotNull(result);
+        assertNotNull(result.getClusters());
+        assertEquals(1, result.getClusters().size());
+        verify(postingClustering, times(1)).cluster(docs);
+    }
+
+    public void testGet_preservesOriginalTermBytes() throws IOException {
+        BytesRef originalTerm = new BytesRef("original_term");
+
+        List<DocumentCluster> expectedClusters = Arrays.asList(mock(DocumentCluster.class));
+        when(postingClustering.cluster(any())).thenReturn(expectedClusters);
+
+        ClusteringTask task = new ClusteringTask(originalTerm, docs, key, postingClustering);
+
+        // Modify original term to ensure deep copy was made
+        originalTerm.bytes[0] = (byte) 'X';
+
+        PostingClusters result = task.get();
+
+        assertNotNull(result);
+        assertNotNull(result.getClusters());
+        assertEquals(1, result.getClusters().size());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/DocumentClusterTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/DocumentClusterTests.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.algorithm;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.common.DocFreq;
+import org.opensearch.neuralsearch.sparse.common.DocFreqIterator;
+import org.opensearch.neuralsearch.sparse.common.SparseVector;
+
+public class DocumentClusterTests extends AbstractSparseTestBase {
+
+    public void testConstructor_withValidInputs_createsCluster() {
+        Map<String, Float> summaryMap = new HashMap<>();
+        summaryMap.put("1", 0.5f);
+        summaryMap.put("2", 0.8f);
+        SparseVector summary = new SparseVector(summaryMap);
+        List<DocFreq> docs = Arrays.asList(new DocFreq(10, (byte) 2), new DocFreq(5, (byte) 1));
+
+        DocumentCluster cluster = new DocumentCluster(summary, docs, false);
+
+        assertEquals(summary, cluster.getSummary());
+        assertEquals(2, cluster.size());
+        assertFalse(cluster.isShouldNotSkip());
+    }
+
+    public void testConstructor_withValidInputsNullSummary_createsCluster() {
+        List<DocFreq> docs = Arrays.asList(new DocFreq(10, (byte) 2), new DocFreq(5, (byte) 1));
+
+        DocumentCluster cluster = new DocumentCluster(null, docs, false);
+
+        assertEquals(null, cluster.getSummary());
+        assertEquals(2, cluster.size());
+        assertFalse(cluster.isShouldNotSkip());
+    }
+
+    public void testConstructor_sortsDocumentsByDocId() {
+        Map<String, Float> summaryMap = new HashMap<>();
+        summaryMap.put("1", 1.0f);
+        SparseVector summary = new SparseVector(summaryMap);
+        List<DocFreq> docs = Arrays.asList(new DocFreq(10, (byte) 2), new DocFreq(5, (byte) 1), new DocFreq(15, (byte) 3));
+
+        DocumentCluster cluster = new DocumentCluster(summary, docs, true);
+
+        Iterator<DocFreq> iterator = cluster.iterator();
+        assertEquals(5, iterator.next().getDocID());
+        assertEquals(10, iterator.next().getDocID());
+        assertEquals(15, iterator.next().getDocID());
+    }
+
+    public void testSize_withEmptyDocs_returnsZero() {
+        List<DocFreq> docs = new ArrayList<>();
+
+        DocumentCluster cluster = new DocumentCluster(null, docs, false);
+
+        assertEquals(0, cluster.size());
+    }
+
+    public void testIterator_withMultipleDocs_iteratesInOrder() {
+        List<DocFreq> docs = Arrays.asList(new DocFreq(20, (byte) 4), new DocFreq(10, (byte) 2), new DocFreq(30, (byte) 6));
+
+        DocumentCluster cluster = new DocumentCluster(null, docs, false);
+        Iterator<DocFreq> iterator = cluster.iterator();
+
+        DocFreq first = iterator.next();
+        assertEquals(10, first.getDocID());
+        assertEquals(2, first.getFreq());
+
+        DocFreq second = iterator.next();
+        assertEquals(20, second.getDocID());
+        assertEquals(4, second.getFreq());
+
+        DocFreq third = iterator.next();
+        assertEquals(30, third.getDocID());
+        assertEquals(6, third.getFreq());
+
+        assertFalse(iterator.hasNext());
+    }
+
+    public void testGetDisi_withValidDocs_returnsCorrectIterator() throws Exception {
+        List<DocFreq> docs = Arrays.asList(new DocFreq(5, (byte) 1), new DocFreq(10, (byte) 2));
+
+        DocumentCluster cluster = new DocumentCluster(null, docs, false);
+        DocFreqIterator disi = cluster.getDisi();
+
+        assertEquals(-1, disi.docID());
+        assertEquals(5, disi.nextDoc());
+        assertEquals(5, disi.docID());
+        assertEquals(1, disi.freq());
+
+        assertEquals(10, disi.nextDoc());
+        assertEquals(10, disi.docID());
+        assertEquals(2, disi.freq());
+
+        assertEquals(DocFreqIterator.NO_MORE_DOCS, disi.nextDoc());
+    }
+
+    public void testGetDisi_withValidDocs_returnsZeroAdvance() throws Exception {
+        List<DocFreq> docs = Arrays.asList(new DocFreq(5, (byte) 1), new DocFreq(10, (byte) 2));
+
+        DocumentCluster cluster = new DocumentCluster(null, docs, false);
+        DocFreqIterator disi = cluster.getDisi();
+
+        assertEquals(-1, disi.docID());
+        assertEquals(5, disi.nextDoc());
+        assertEquals(0, disi.advance(disi.docID()));
+
+        assertEquals(10, disi.nextDoc());
+        assertEquals(0, disi.advance(disi.docID()));
+
+        assertEquals(DocFreqIterator.NO_MORE_DOCS, disi.nextDoc());
+    }
+
+    public void testGetDisi_withValidDocs_returnsZeroCost() throws Exception {
+        List<DocFreq> docs = Arrays.asList(new DocFreq(5, (byte) 1), new DocFreq(10, (byte) 2));
+
+        DocumentCluster cluster = new DocumentCluster(null, docs, false);
+        DocFreqIterator disi = cluster.getDisi();
+
+        assertEquals(-1, disi.docID());
+        assertEquals(5, disi.nextDoc());
+        assertEquals(0, disi.cost());
+
+        assertEquals(10, disi.nextDoc());
+        assertEquals(0, disi.cost());
+
+        assertEquals(DocFreqIterator.NO_MORE_DOCS, disi.nextDoc());
+    }
+
+    public void testRamBytesUsed_withNullSummary_returnsPositiveValue() {
+        List<DocFreq> docs = Arrays.asList(new DocFreq(1, (byte) 1));
+
+        DocumentCluster cluster = new DocumentCluster(null, docs, false);
+
+        assertTrue(cluster.ramBytesUsed() > 0);
+    }
+
+    public void testRamBytesUsed_withSummary_includesSummarySize() {
+        Map<String, Float> summaryMap = new HashMap<>();
+        summaryMap.put("1", 0.5f);
+        summaryMap.put("2", 0.8f);
+        SparseVector summary = new SparseVector(summaryMap);
+        List<DocFreq> docs = Arrays.asList(new DocFreq(1, (byte) 1));
+
+        DocumentCluster cluster = new DocumentCluster(summary, docs, false);
+
+        assertTrue(cluster.ramBytesUsed() > 0);
+    }
+
+    public void testGetChildResources_withNullSummary_returnsEmptyList() {
+        List<DocFreq> docs = Arrays.asList(new DocFreq(1, (byte) 1));
+
+        DocumentCluster cluster = new DocumentCluster(null, docs, false);
+
+        assertTrue(cluster.getChildResources().isEmpty());
+    }
+
+    public void testGetChildResources_withSummary_returnsSummary() {
+        Map<String, Float> summaryMap = new HashMap<>();
+        summaryMap.put("1", 1.0f);
+        SparseVector summary = new SparseVector(summaryMap);
+        List<DocFreq> docs = Arrays.asList(new DocFreq(1, (byte) 1));
+
+        DocumentCluster cluster = new DocumentCluster(summary, docs, false);
+
+        assertEquals(1, cluster.getChildResources().size());
+        assertTrue(cluster.getChildResources().contains(summary));
+    }
+
+    public void testEquals_withSameValues_returnsTrue() {
+        Map<String, Float> summaryMap = new HashMap<>();
+        summaryMap.put("1", 1.0f);
+        SparseVector summary = new SparseVector(summaryMap);
+        List<DocFreq> docs = Arrays.asList(new DocFreq(1, (byte) 1));
+
+        DocumentCluster cluster1 = new DocumentCluster(summary, docs, false);
+        DocumentCluster cluster2 = new DocumentCluster(summary, docs, false);
+
+        assertEquals(cluster1, cluster2);
+    }
+
+    public void testEquals_withDifferentShouldNotSkip_returnsFalse() {
+        Map<String, Float> summaryMap = new HashMap<>();
+        summaryMap.put("1", 1.0f);
+        SparseVector summary = new SparseVector(summaryMap);
+        List<DocFreq> docs = Arrays.asList(new DocFreq(1, (byte) 1));
+
+        DocumentCluster cluster1 = new DocumentCluster(summary, docs, true);
+        DocumentCluster cluster2 = new DocumentCluster(summary, docs, false);
+
+        assertNotEquals(cluster1, cluster2);
+    }
+
+    public void testHashCode_withSameValues_returnsSameHashCode() {
+        Map<String, Float> summaryMap = new HashMap<>();
+        summaryMap.put("1", 1.0f);
+        SparseVector summary = new SparseVector(summaryMap);
+        List<DocFreq> docs = Arrays.asList(new DocFreq(1, (byte) 1));
+
+        DocumentCluster cluster1 = new DocumentCluster(summary, docs, false);
+        DocumentCluster cluster2 = new DocumentCluster(summary, docs, false);
+
+        assertEquals(cluster1.hashCode(), cluster2.hashCode());
+    }
+
+    public void testSetSummary_updatesCorrectly() {
+        Map<String, Float> originalSummaryMap = new HashMap<>();
+        originalSummaryMap.put("1", 1.0f);
+        SparseVector originalSummary = new SparseVector(originalSummaryMap);
+
+        Map<String, Float> newSummaryMap = new HashMap<>();
+        newSummaryMap.put("2", 2.0f);
+        SparseVector newSummary = new SparseVector(newSummaryMap);
+
+        List<DocFreq> docs = Arrays.asList(new DocFreq(1, (byte) 1));
+
+        DocumentCluster cluster = new DocumentCluster(originalSummary, docs, false);
+        cluster.setSummary(newSummary);
+
+        assertEquals(newSummary, cluster.getSummary());
+    }
+
+    public void testSetShouldNotSkip_updatesCorrectly() {
+        Map<String, Float> summaryMap = new HashMap<>();
+        summaryMap.put("1", 1.0f);
+        SparseVector summary = new SparseVector(summaryMap);
+        List<DocFreq> docs = Arrays.asList(new DocFreq(1, (byte) 1));
+
+        DocumentCluster cluster = new DocumentCluster(summary, docs, false);
+        cluster.setShouldNotSkip(true);
+
+        assertTrue(cluster.isShouldNotSkip());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/SeismicTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/SeismicTests.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.algorithm;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.opensearch.common.ValidationException;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.mapper.SparseMethodContext;
+
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SUMMARY_PRUNE_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.N_POSTINGS_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.CLUSTER_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.ALGO_TRIGGER_DOC_COUNT_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.NAME_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.PARAMETERS_FIELD;
+
+public class SeismicTests extends AbstractSparseTestBase {
+
+    public void testValidateMethod_invalidAlgoTriggerDocCount() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(ALGO_TRIGGER_DOC_COUNT_FIELD, -1);
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNotNull(result);
+        assertTrue(result.validationErrors().contains("algo trigger doc count should be a non-negative integer"));
+    }
+
+    public void testValidateMethod_invalidClusterRatio() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(CLUSTER_RATIO_FIELD, 1.0f);
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNotNull(result);
+        assertTrue(result.validationErrors().contains("cluster ratio should be in (0, 1)"));
+    }
+
+    public void testValidateMethod_invalidNPostings() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(N_POSTINGS_FIELD, -1);
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNotNull(result);
+        assertTrue(result.validationErrors().contains("n_postings should be a positive integer"));
+    }
+
+    public void testValidateMethod_invalidSummaryPruneRatio() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SUMMARY_PRUNE_RATIO_FIELD, 2.0f);
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNotNull(result);
+        assertTrue(result.validationErrors().contains("summary prune ratio should be in (0, 1]"));
+    }
+
+    public void testValidateMethod_multipleInvalidParameters() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(N_POSTINGS_FIELD, 0);
+        parameters.put(CLUSTER_RATIO_FIELD, 1.5f);
+        parameters.put(ALGO_TRIGGER_DOC_COUNT_FIELD, -1);
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext sparseMethodContext = SparseMethodContext.parse(methodMap);
+
+        ValidationException validationException = Seismic.INSTANCE.validateMethod(sparseMethodContext);
+
+        assertNotNull(validationException);
+        assertTrue(validationException.validationErrors().contains("n_postings should be a positive integer"));
+        assertTrue(validationException.validationErrors().contains("cluster ratio should be in (0, 1)"));
+        assertTrue(validationException.validationErrors().contains("algo trigger doc count should be a non-negative integer"));
+    }
+
+    public void testValidateMethod_unknownParameter() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("unknown_param", "value");
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNotNull(result);
+        assertTrue(result.validationErrors().contains("Unknown parameter 'unknown_param' found"));
+    }
+
+    public void testValidateMethod_validParameters() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SUMMARY_PRUNE_RATIO_FIELD, 0.5f);
+        parameters.put(N_POSTINGS_FIELD, 10);
+        parameters.put(CLUSTER_RATIO_FIELD, 0.5f);
+        parameters.put(ALGO_TRIGGER_DOC_COUNT_FIELD, 100);
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext sparseMethodContext = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(sparseMethodContext);
+
+        assertNull(result);
+    }
+
+    public void testValidateMethod_allInvalidParameters() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SUMMARY_PRUNE_RATIO_FIELD, 0.0f);
+        parameters.put(N_POSTINGS_FIELD, 0);
+        parameters.put(CLUSTER_RATIO_FIELD, 1.0f);
+        parameters.put(ALGO_TRIGGER_DOC_COUNT_FIELD, -1);
+        parameters.put("unknown_param", "value");
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext sparseMethodContext = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(sparseMethodContext);
+
+        assertNotNull(result);
+        assertTrue(result.validationErrors().contains("summary prune ratio should be in (0, 1]"));
+        assertTrue(result.validationErrors().contains("n_postings should be a positive integer"));
+        assertTrue(result.validationErrors().contains("cluster ratio should be in (0, 1)"));
+        assertTrue(result.validationErrors().contains("algo trigger doc count should be a non-negative integer"));
+        assertTrue(result.validationErrors().contains("Unknown parameter 'unknown_param' found"));
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/common/DocFreqTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/common/DocFreqTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.common;
+
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+
+public class DocFreqTests extends AbstractSparseTestBase {
+
+    public void testGetDocID_afterConstruction_returnsCorrectValue() {
+        int docID = 42;
+        byte freq = 5;
+        DocFreq docFreq = new DocFreq(docID, freq);
+        assertEquals(docID, docFreq.getDocID());
+    }
+
+    public void testGetFreq_afterConstruction_returnsCorrectValue() {
+        int docID = 42;
+        byte freq = 5;
+        DocFreq docFreq = new DocFreq(docID, freq);
+        assertEquals(freq, docFreq.getFreq());
+    }
+
+    public void testGetIntFreq_withPositiveByteValue_returnsCorrectValue() {
+        DocFreq docFreq = new DocFreq(1, (byte) 5);
+        assertEquals(5, docFreq.getIntFreq());
+    }
+
+    public void testGetIntFreq_withNegativeByteValue_returnsUnsignedValue() {
+        DocFreq docFreq = new DocFreq(2, (byte) 0xFF); // -1 as signed byte, 255 as unsigned
+        assertEquals(255, docFreq.getIntFreq());
+    }
+
+    public void testGetIntFreq_withZeroValue_returnsZero() {
+        DocFreq docFreq = new DocFreq(3, (byte) 0);
+        assertEquals(0, docFreq.getIntFreq());
+    }
+
+    public void testGetIntFreq_withMaxSignedByteValue_returnsCorrectValue() {
+        DocFreq docFreq = new DocFreq(4, (byte) 127);
+        assertEquals(127, docFreq.getIntFreq());
+    }
+
+    public void testCompareTo_withSmallerDocID_returnsNegative() {
+        DocFreq docFreq1 = new DocFreq(1, (byte) 10);
+        DocFreq docFreq2 = new DocFreq(2, (byte) 5);
+        assertTrue(docFreq1.compareTo(docFreq2) < 0);
+    }
+
+    public void testCompareTo_withLargerDocID_returnsPositive() {
+        DocFreq docFreq1 = new DocFreq(2, (byte) 5);
+        DocFreq docFreq2 = new DocFreq(1, (byte) 10);
+        assertTrue(docFreq1.compareTo(docFreq2) > 0);
+    }
+
+    public void testCompareTo_withSameDocID_returnsZero() {
+        DocFreq docFreq1 = new DocFreq(1, (byte) 10);
+        DocFreq docFreq2 = new DocFreq(1, (byte) 20);
+        assertEquals(0, docFreq1.compareTo(docFreq2));
+    }
+
+    public void testEquals_withSameValues_returnsTrue() {
+        DocFreq docFreq1 = new DocFreq(1, (byte) 10);
+        DocFreq docFreq2 = new DocFreq(1, (byte) 10);
+        assertEquals(docFreq1, docFreq2);
+    }
+
+    public void testEquals_withDifferentFreq_returnsFalse() {
+        DocFreq docFreq1 = new DocFreq(1, (byte) 10);
+        DocFreq docFreq2 = new DocFreq(1, (byte) 20);
+        assertNotEquals(docFreq1, docFreq2);
+    }
+
+    public void testEquals_withDifferentDocID_returnsFalse() {
+        DocFreq docFreq1 = new DocFreq(1, (byte) 10);
+        DocFreq docFreq2 = new DocFreq(2, (byte) 10);
+        assertNotEquals(docFreq1, docFreq2);
+    }
+
+    public void testEquals_withNull_returnsFalse() {
+        DocFreq docFreq = new DocFreq(1, (byte) 10);
+        assertNotEquals(docFreq, null);
+    }
+
+    public void testEquals_withDifferentType_returnsFalse() {
+        DocFreq docFreq = new DocFreq(1, (byte) 10);
+        assertNotEquals(docFreq, "not a DocFreq");
+    }
+
+    public void testHashCode_withEqualObjects_returnsSameValue() {
+        DocFreq docFreq1 = new DocFreq(1, (byte) 10);
+        DocFreq docFreq2 = new DocFreq(1, (byte) 10);
+        assertEquals(docFreq1.hashCode(), docFreq2.hashCode());
+    }
+
+    public void testCompareTo_withMinAndMaxValues_returnsNegative() {
+        DocFreq minDocFreq = new DocFreq(Integer.MIN_VALUE, (byte) 0);
+        DocFreq maxDocFreq = new DocFreq(Integer.MAX_VALUE, (byte) 0);
+        assertTrue(minDocFreq.compareTo(maxDocFreq) < 0);
+    }
+
+    public void testCompareTo_withMaxAndMinValues_returnsPositive() {
+        DocFreq minDocFreq = new DocFreq(Integer.MIN_VALUE, (byte) 0);
+        DocFreq maxDocFreq = new DocFreq(Integer.MAX_VALUE, (byte) 0);
+        assertTrue(maxDocFreq.compareTo(minDocFreq) > 0);
+    }
+
+    public void testCompareTo_withSameObject_returnsZero() {
+        DocFreq docFreq = new DocFreq(1, (byte) 10);
+        assertEquals(0, docFreq.compareTo(docFreq));
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/common/IteratorWrapperTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/common/IteratorWrapperTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.common;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+
+public class IteratorWrapperTests extends AbstractSparseTestBase {
+
+    private void assertIteratorResults(IteratorWrapper<Integer> wrapper, Integer... expected) {
+        for (Integer expectedValue : expected) {
+            assertEquals(expectedValue, wrapper.next());
+            assertEquals(expectedValue, wrapper.getCurrent());
+        }
+    }
+
+    public void testIteratorWrapperWithNullIterator() {
+        IteratorWrapper<String> wrapper = new IteratorWrapper<>(null);
+        expectThrows(NullPointerException.class, wrapper::hasNext);
+    }
+
+    public void testNextWhenHasNext() {
+        Iterator<Integer> iterator = Arrays.asList(1, 2, 3).iterator();
+        IteratorWrapper<Integer> wrapper = new IteratorWrapper<>(iterator);
+
+        assertIteratorResults(wrapper, 1, 2, 3);
+    }
+
+    public void testNextWhenNoMoreElements() {
+        Iterator<String> emptyIterator = Collections.emptyIterator();
+        IteratorWrapper<String> wrapper = new IteratorWrapper<>(emptyIterator);
+
+        assertNull(wrapper.next());
+    }
+
+    public void testNextWithEmptyIterator() {
+        Iterator<String> emptyIterator = Collections.emptyIterator();
+        IteratorWrapper<String> wrapper = new IteratorWrapper<>(emptyIterator);
+
+        assertNull(wrapper.next());
+    }
+
+    public void testIteratorWrapperInitialization() {
+        Iterator<Integer> iterator = Arrays.asList(1, 2, 3).iterator();
+        IteratorWrapper<Integer> wrapper = new IteratorWrapper<>(iterator);
+
+        assertNotNull(wrapper);
+        assertNull(wrapper.getCurrent());
+        assertTrue(wrapper.hasNext());
+    }
+
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/mapper/MethodComponentContextTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/mapper/MethodComponentContextTests.java
@@ -1,0 +1,418 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.mapper;
+
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.index.mapper.MapperParsingException;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.any;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.NAME_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.PARAMETERS_FIELD;
+
+public class MethodComponentContextTests extends AbstractSparseTestBase {
+
+    public void testConstructorWithNullParameter() {
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> {
+            new MethodComponentContext((MethodComponentContext) null);
+        });
+        assertNotNull(exception);
+    }
+
+    public void testEqualsWithDifferentClass() {
+        MethodComponentContext context = new MethodComponentContext("test", new HashMap<>());
+        assertFalse(context.equals(new Object()));
+    }
+
+    public void testEqualsWithDifferentName() {
+        MethodComponentContext context1 = new MethodComponentContext("test1", new HashMap<>());
+        MethodComponentContext context2 = new MethodComponentContext("test2", new HashMap<>());
+        assertFalse(context1.equals(context2));
+    }
+
+    public void testEqualsWithDifferentParameters() {
+        Map<String, Object> params1 = new HashMap<>();
+        params1.put("key", "value1");
+        Map<String, Object> params2 = new HashMap<>();
+        params2.put("key", "value2");
+
+        MethodComponentContext context1 = new MethodComponentContext("test", params1);
+        MethodComponentContext context2 = new MethodComponentContext("test", params2);
+        assertFalse(context1.equals(context2));
+    }
+
+    public void testEqualsWithNull() {
+        MethodComponentContext context = new MethodComponentContext("test", new HashMap<>());
+        assertFalse(context.equals(null));
+    }
+
+    public void testFromXContentWithEmptyMap() throws IOException {
+        XContentParser mockParser = mock(XContentParser.class);
+        when(mockParser.currentToken()).thenReturn(null);
+        when(mockParser.nextToken()).thenReturn(XContentParser.Token.START_OBJECT);
+        when(mockParser.map()).thenReturn(new HashMap<>());
+
+        MapperParsingException exception = expectThrows(
+                MapperParsingException.class,
+                () -> { MethodComponentContext.fromXContent(mockParser); }
+        );
+        assertEquals("name needs to be set", exception.getMessage());
+    }
+
+    public void testFromXContentWithEndOfInput() throws IOException {
+        XContentParser mockParser = mock(XContentParser.class);
+        when(mockParser.currentToken()).thenReturn(null);
+        when(mockParser.nextToken()).thenReturn(null);
+
+        MapperParsingException exception = expectThrows(
+                MapperParsingException.class,
+                () -> { MethodComponentContext.fromXContent(mockParser); }
+        );
+        assertEquals("name needs to be set", exception.getMessage());
+    }
+
+    public void testGetFloatWithNonNumberValue() {
+        MethodComponentContext context = new MethodComponentContext("test", Map.of("key", "not a number"));
+        Float defaultValue = 1.0f;
+        Float result = context.getFloat("key", defaultValue);
+        assertEquals(defaultValue, result);
+    }
+
+    public void testMethodComponentContextWithEmptyStreamInput() throws IOException {
+        StreamInput mockStreamInput = mock(StreamInput.class);
+        when(mockStreamInput.readString()).thenReturn("testName");
+        when(mockStreamInput.available()).thenReturn(0);
+
+        MethodComponentContext context = new MethodComponentContext(mockStreamInput);
+        assertTrue(context.getParameters().isEmpty());
+    }
+
+    public void testParseWithEmptyName() {
+        Map<String, Object> input = new HashMap<>();
+        input.put("name", "");
+        input.put("parameters", new HashMap<>());
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> { MethodComponentContext.parse(input); });
+        assertEquals("name needs to be set", exception.getMessage());
+    }
+
+    public void testParseWithInvalidKey() {
+        Map<String, Object> input = new HashMap<>();
+        input.put("name", "validName");
+        input.put("invalidKey", "value");
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> { MethodComponentContext.parse(input); });
+        assertEquals("Invalid parameter for MethodComponentContext: invalidKey", exception.getMessage());
+    }
+
+    public void testParseNullParameters() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(NAME_FIELD, "test_method");
+        input.put(PARAMETERS_FIELD, null);
+
+        MethodComponentContext result = MethodComponentContext.parse(input);
+
+        assertEquals("test_method", result.getName());
+        assertTrue(result.getParameters().isEmpty());
+    }
+
+    public void testParseWithNestedParameters() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(NAME_FIELD, "test_method");
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("param1", "value1");
+
+        Map<String, Object> nestedParam = new HashMap<>();
+        nestedParam.put(NAME_FIELD, "nested_method");
+        nestedParam.put(PARAMETERS_FIELD, new HashMap<>());
+        parameters.put("param2", nestedParam);
+
+        input.put(PARAMETERS_FIELD, parameters);
+
+        MethodComponentContext result = MethodComponentContext.parse(input);
+
+        assertEquals("test_method", result.getName());
+        assertEquals("value1", result.getParameters().get("param1"));
+        assertTrue(result.getParameters().get("param2") instanceof MethodComponentContext);
+
+        MethodComponentContext nestedResult = (MethodComponentContext) result.getParameters().get("param2");
+        assertEquals("nested_method", nestedResult.getName());
+        assertTrue(nestedResult.getParameters().isEmpty());
+    }
+
+    public void testParseWithNonMapInput() {
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> { MethodComponentContext.parse("Not a Map"); });
+        assertEquals("Unable to parse MethodComponent", exception.getMessage());
+    }
+
+    public void testParseWithNonMapParameters() {
+        Map<String, Object> input = new HashMap<>();
+        input.put("name", "validName");
+        input.put("parameters", "Not a Map");
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> { MethodComponentContext.parse(input); });
+        assertEquals("Unable to parse parameters for method component", exception.getMessage());
+    }
+
+    public void testParseWithNonStringName() {
+        Map<String, Object> input = new HashMap<>();
+        input.put("name", 123);
+        input.put("parameters", new HashMap<>());
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> { MethodComponentContext.parse(input); });
+        assertEquals("Component name should be a string", exception.getMessage());
+    }
+
+    public void testToXContentWithNestedMethodComponentContext() throws IOException {
+        String name = "parentMethod";
+        Map<String, Object> nestedParams = new HashMap<>();
+        nestedParams.put("nestedParam", "nestedValue");
+        MethodComponentContext nestedContext = new MethodComponentContext("nested_method", nestedParams);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("nestedContext", nestedContext);
+        MethodComponentContext context = new MethodComponentContext(name, params);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        context.toXContent(builder, null);
+        builder.endObject();
+
+        String expected =
+                "{\"name\":\"parentMethod\",\"parameters\":{\"nestedContext\":{\"name\":\"nested_method\",\"parameters\":{\"nestedParam\":\"nestedValue\"}}}}";
+        assertEquals(expected, builder.toString());
+    }
+
+    public void testToXContentWithNullParameters() throws IOException {
+        String name = "test_method";
+        MethodComponentContext context = new MethodComponentContext(name, null);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        context.toXContent(builder, null);
+        builder.endObject();
+
+        String expected = "{\"name\":\"test_method\",\"parameters\":null}";
+        assertEquals(expected, builder.toString());
+    }
+
+    public void testToXContentWithIOExceptionHandling() throws IOException {
+        // Create a MethodComponentContext with a parameter that will cause an IOException
+        String name = "errorMethod";
+        Map<String, Object> params = new HashMap<>();
+
+        // Create a mock MethodComponentContext that throws IOException when toXContent is called
+        MethodComponentContext problematicNestedContext = mock(MethodComponentContext.class);
+        doThrow(new IOException("Test IOException")).when(problematicNestedContext).toXContent(any(), any());
+
+        params.put("problematicContext", problematicNestedContext);
+        MethodComponentContext context = new MethodComponentContext(name, params);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+
+        // The toXContent method should throw a RuntimeException wrapping the IOException
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> context.toXContent(builder, null));
+
+        // Verify the exception message
+        assertEquals("Unable to generate xcontent for method component", exception.getMessage());
+
+        builder.endObject();
+    }
+
+    public void testCopyConstructorWithNonMethodComponentContextParameters() {
+        String name = "test_method";
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("param1", "value1");
+        parameters.put("param2", 42);
+
+        MethodComponentContext original = new MethodComponentContext(name, parameters);
+        MethodComponentContext copy = new MethodComponentContext(original);
+
+        assertNotNull(copy);
+        assertEquals(name, copy.getName());
+        assertNotNull(copy.getParameters());
+        assertEquals(2, copy.getParameters().size());
+        assertEquals("value1", copy.getParameters().get("param1"));
+        assertEquals(42, copy.getParameters().get("param2"));
+    }
+
+    public void testDeepCopyWithNestedParameters() {
+        Map<String, Object> nestedParams = new HashMap<>();
+        nestedParams.put("nestedKey", "nestedValue");
+        MethodComponentContext nestedContext = new MethodComponentContext("nestedComponent", nestedParams);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("key1", "value1");
+        params.put("nestedContext", nestedContext);
+        MethodComponentContext originalContext = new MethodComponentContext("mainComponent", params);
+
+        MethodComponentContext copiedContext = new MethodComponentContext(originalContext);
+
+        assertNotSame(originalContext, copiedContext);
+        assertEquals(originalContext.getName(), copiedContext.getName());
+        assertNotSame(originalContext.getParameters(), copiedContext.getParameters());
+        assertEquals(originalContext.getParameters().size(), copiedContext.getParameters().size());
+
+        assertTrue(copiedContext.getParameters().get("nestedContext") instanceof MethodComponentContext);
+        MethodComponentContext copiedNestedContext = (MethodComponentContext) copiedContext.getParameters().get("nestedContext");
+        assertNotSame(nestedContext, copiedNestedContext);
+        assertEquals(nestedContext.getName(), copiedNestedContext.getName());
+        assertEquals(nestedContext.getParameters(), copiedNestedContext.getParameters());
+    }
+
+    public void testEqualsIdenticalObjects() {
+        String name = "test_method";
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("param1", "value1");
+        parameters.put("param2", 42);
+
+        MethodComponentContext context1 = new MethodComponentContext(name, parameters);
+        MethodComponentContext context2 = new MethodComponentContext(name, parameters);
+
+        assertTrue(context1.equals(context2));
+        assertTrue(context2.equals(context1));
+    }
+
+    public void testFromXContentWithValidInput() throws IOException {
+        String json = "{\"name\":\"test_method\",\"parameters\":{\"param1\":\"value1\"}}";
+        XContentParser parser = JsonXContent.jsonXContent.createParser(null, null, json);
+
+        MethodComponentContext result = MethodComponentContext.fromXContent(parser);
+
+        assertNotNull(result);
+        assertEquals("test_method", result.getName());
+        assertTrue(result.getParameters().containsKey("param1"));
+        assertEquals("value1", result.getParameters().get("param1"));
+    }
+
+    public void testGetFloatWhenParameterIsNumber() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("testKey", 42);
+        MethodComponentContext context = new MethodComponentContext("testName", parameters);
+
+        Float result = context.getFloat("testKey", 0.0f);
+
+        assertEquals(42.0f, result, 0.001f);
+    }
+
+    public void testGetParameterWhenKeyExists() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("testKey", "testValue");
+        MethodComponentContext context = new MethodComponentContext("testName", parameters);
+
+        Object result = context.getParameter("testKey", "defaultValue");
+
+        assertEquals("testValue", result);
+    }
+
+    public void testGetParametersWhenParametersIsNull() {
+        MethodComponentContext context = new MethodComponentContext("testComponent", null);
+        Map<String, Object> result = context.getParameters();
+        assertEquals(Collections.emptyMap(), result);
+    }
+
+    public void testHashCode() {
+        String name = "testName";
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("key1", "value1");
+        parameters.put("key2", 42);
+
+        MethodComponentContext context = new MethodComponentContext(name, parameters);
+
+        int expectedHashCode = new HashCodeBuilder().append(name).append(parameters).toHashCode();
+        int actualHashCode = context.hashCode();
+
+        assertEquals(expectedHashCode, actualHashCode);
+    }
+
+    public void testHashCodeDifferentNamesEqualParameters() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("key", "value");
+
+        MethodComponentContext context1 = new MethodComponentContext("name1", parameters);
+        MethodComponentContext context2 = new MethodComponentContext("name2", parameters);
+
+        assertNotEquals(context1.hashCode(), context2.hashCode());
+    }
+
+    public void testWriteToAndReadFrom() throws IOException {
+        String name = "test_method";
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("param1", "value1");
+        parameters.put("param2", 42);
+
+        MethodComponentContext context = new MethodComponentContext(name, parameters);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        context.writeTo(out);
+
+        BytesReference bytesRef = out.bytes();
+        StreamInput in = bytesRef.streamInput();
+        MethodComponentContext readContext = new MethodComponentContext(in);
+
+        assertEquals(name, readContext.getName());
+        assertEquals(parameters, readContext.getParameters());
+    }
+
+    public void testWriteToWithNullParameters() throws IOException {
+        String name = "test_method";
+        MethodComponentContext context = new MethodComponentContext(name, null);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        context.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        String writtenName = in.readString();
+        assertEquals(name, writtenName);
+        assertEquals(0, in.available());
+    }
+
+    public void testParameterMapValueReaderWithMethodComponentContext() throws IOException {
+        Map<String, Object> nestedParams = new HashMap<>();
+        nestedParams.put("key", "value");
+        MethodComponentContext nestedContext = new MethodComponentContext("nested", nestedParams);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("nested_context", nestedContext);
+        MethodComponentContext context = new MethodComponentContext("test", params);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        context.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MethodComponentContext readContext = new MethodComponentContext(in);
+
+        assertTrue(readContext.getParameters().get("nested_context") instanceof MethodComponentContext);
+    }
+
+    public void testParameterMapValueWriterWithMethodComponentContext() throws IOException {
+        MethodComponentContext nestedContext = new MethodComponentContext("nested", new HashMap<>());
+        Map<String, Object> params = new HashMap<>();
+        params.put("nested_context", nestedContext);
+        MethodComponentContext context = new MethodComponentContext("test", params);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        context.writeTo(out);
+
+        assertTrue(out.bytes().length() > 0);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/mapper/SparseMethodContextTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/mapper/SparseMethodContextTests.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.mapper;
+
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.index.mapper.MapperParsingException;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.NAME_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.PARAMETERS_FIELD;
+
+public class SparseMethodContextTests extends AbstractSparseTestBase {
+
+    @Mock
+    private StreamInput mockStreamInput;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+    }
+
+    public void testParseWithEmptyName() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(NAME_FIELD, "");
+        input.put(PARAMETERS_FIELD, new HashMap<>());
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> { SparseMethodContext.parse(input); });
+        assertEquals("name needs to be set", exception.getMessage());
+    }
+
+    public void testParseWithInvalidParameterKey() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(NAME_FIELD, "testMethod");
+        input.put("invalidKey", "someValue");
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> { SparseMethodContext.parse(input); });
+        assertEquals("Invalid parameter: invalidKey", exception.getMessage());
+    }
+
+    public void testParseWithInvalidParametersType() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(NAME_FIELD, "testMethod");
+        input.put(PARAMETERS_FIELD, "Not a map");
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> { SparseMethodContext.parse(input); });
+        assertEquals("Unable to parse parameters for main method component", exception.getMessage());
+    }
+
+    public void testParseWithNonMapInput() {
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> { SparseMethodContext.parse("Not a map"); });
+        assertEquals("Unable to parse mapping into SparseMethodContext. Object not of type \"Map\"", exception.getMessage());
+    }
+
+    public void testSparseMethodContextConstructorWithIOException() throws IOException {
+        StreamInput mockInput = mock(StreamInput.class);
+        when(mockInput.readString()).thenThrow(new IOException("Simulated IO error"));
+
+        expectThrows(IOException.class, () -> { new SparseMethodContext(mockInput); });
+    }
+
+    public void testSparseMethodConstructorWithStreamInput() throws IOException {
+        StreamInput mockStreamInput = mock(StreamInput.class);
+        when(mockStreamInput.readString()).thenReturn("testMethod");
+
+        SparseMethodContext sparseMethodContext = new SparseMethodContext(mockStreamInput);
+
+        assertEquals("testMethod", sparseMethodContext.getName());
+        assertNotNull(sparseMethodContext.getMethodComponentContext());
+    }
+
+    public void testParseInvalidParameterAndEmptyName() {
+        Map<String, Object> inputMap = new HashMap<>();
+        inputMap.put("invalid_key", "some_value");
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> { SparseMethodContext.parse(inputMap); });
+        assertEquals("Invalid parameter: invalid_key", exception.getMessage());
+    }
+
+    public void testParseNullParameters() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(NAME_FIELD, "testMethod");
+        input.put(PARAMETERS_FIELD, null);
+
+        SparseMethodContext result = SparseMethodContext.parse(input);
+
+        assertEquals("testMethod", result.getName());
+        assertTrue(result.getMethodComponentContext().getParameters().isEmpty());
+    }
+
+    public void testParseValidNameOnly() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(NAME_FIELD, "testMethod");
+
+        SparseMethodContext result = SparseMethodContext.parse(input);
+
+        assertEquals("testMethod", result.getName());
+        assertEquals(new HashMap<>(), result.getMethodComponentContext().getParameters());
+    }
+
+    public void testParseWithNestedMethodComponentContext() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(NAME_FIELD, "test_method");
+
+        Map<String, Object> parameters = new HashMap<>();
+        Map<String, Object> nestedMap = new HashMap<>();
+        nestedMap.put(NAME_FIELD, "nested_method");
+        nestedMap.put(PARAMETERS_FIELD, new HashMap<>());
+        parameters.put("nested_param", nestedMap);
+        input.put(PARAMETERS_FIELD, parameters);
+
+        SparseMethodContext result = SparseMethodContext.parse(input);
+
+        assertNotNull(result);
+        assertEquals("test_method", result.getName());
+        assertNotNull(result.getMethodComponentContext());
+        assertEquals("test_method", result.getMethodComponentContext().getName());
+
+        Map<String, Object> resultParameters = result.getMethodComponentContext().getParameters();
+        assertNotNull(resultParameters);
+        assertEquals(1, resultParameters.size());
+        assertTrue(resultParameters.get("nested_param") instanceof MethodComponentContext);
+
+        MethodComponentContext nestedContext = (MethodComponentContext) resultParameters.get("nested_param");
+        assertEquals("nested_method", nestedContext.getName());
+        assertNotNull(nestedContext.getParameters());
+        assertTrue(nestedContext.getParameters().isEmpty());
+    }
+
+    public void testToXContentSerializesCorrectly() throws IOException {
+        String name = "test_method";
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("param1", "value1");
+        parameters.put("param2", 42);
+
+        MethodComponentContext methodComponentContext = new MethodComponentContext(name, parameters);
+        SparseMethodContext sparseMethodContext = new SparseMethodContext(name, methodComponentContext);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        sparseMethodContext.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        String result = builder.toString();
+        assertTrue(result.contains("test_method"));
+        assertTrue(result.contains("param1"));
+        assertTrue(result.contains("value1"));
+        assertTrue(result.contains("param2"));
+        assertTrue(result.contains("42"));
+    }
+
+    public void testWriteToAndReadFrom() throws IOException {
+        String name = "testMethod";
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("param1", "value1");
+        parameters.put("param2", 42);
+        MethodComponentContext methodComponentContext = new MethodComponentContext(name, parameters);
+        SparseMethodContext sparseMethodContext = new SparseMethodContext(name, methodComponentContext);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        sparseMethodContext.writeTo(out);
+
+        BytesReference bytesRef = out.bytes();
+        StreamInput in = bytesRef.streamInput();
+        SparseMethodContext readContext = new SparseMethodContext(in);
+
+        assertEquals(name, readContext.getName());
+        assertEquals(methodComponentContext, readContext.getMethodComponentContext());
+    }
+
+    public void testParseWithNonMapParameterValues() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(NAME_FIELD, "testMethod");
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("stringParam", "stringValue");
+        parameters.put("intParam", 42);
+        parameters.put("boolParam", true);
+        input.put(PARAMETERS_FIELD, parameters);
+
+        SparseMethodContext result = SparseMethodContext.parse(input);
+
+        assertEquals("testMethod", result.getName());
+        Map<String, Object> resultParams = result.getMethodComponentContext().getParameters();
+        assertEquals("stringValue", resultParams.get("stringParam"));
+        assertEquals(42, resultParams.get("intParam"));
+        assertEquals(true, resultParams.get("boolParam"));
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldMapperTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldMapperTests.java
@@ -1,0 +1,391 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.mapper;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.mockito.MockitoAnnotations;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.mapper.MapperParsingException;
+import org.opensearch.index.mapper.Mapper;
+import org.opensearch.index.mapper.ParametrizedFieldMapper;
+import org.opensearch.index.mapper.ParseContext;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.testsPrepareUtils;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.ToXContent;
+
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SUMMARY_PRUNE_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.N_POSTINGS_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.CLUSTER_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.ALGO_TRIGGER_DOC_COUNT_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.NAME_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.PARAMETERS_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SEISMIC;
+
+public class SparseTokensFieldMapperTests extends AbstractSparseTestBase {
+    private SparseTokensFieldMapper.Builder builder;
+    private SparseMethodContext sparseMethodContext;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SUMMARY_PRUNE_RATIO_FIELD, 0.5f);
+        parameters.put(N_POSTINGS_FIELD, 10);
+        parameters.put(CLUSTER_RATIO_FIELD, 0.3f);
+        parameters.put(ALGO_TRIGGER_DOC_COUNT_FIELD, 100);
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, SEISMIC);
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        sparseMethodContext = SparseMethodContext.parse(methodMap);
+
+        builder = new SparseTokensFieldMapper.Builder("test_field");
+    }
+
+    public void testBuilder_withValidParameters_createsBuilder() {
+        assertNotNull(builder);
+        assertEquals("test_field", builder.name());
+    }
+
+    public void testBuilder_build_createsFieldMapper() {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+                new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        assertNotNull(mapper);
+        assertEquals("test_field", mapper.simpleName());
+        assertEquals(SparseTokensFieldMapper.CONTENT_TYPE, mapper.contentType());
+        assertEquals(sparseMethodContext, mapper.getSparseMethodContext());
+    }
+
+    public void testBuilder_withStoredTrue_setsStoredCorrectly() {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        builder.stored.setValue(true);
+
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+                new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        assertTrue(mapper.isStored());
+    }
+
+    public void testBuilder_withDocValuesFalse_setsDocValuesCorrectly() {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        builder.hasDocValues.setValue(false);
+
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+                new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        assertFalse(mapper.isHasDocValues());
+    }
+
+    public void testContentType_returnsCorrectValue() {
+        assertEquals("sparse_tokens", SparseTokensFieldMapper.CONTENT_TYPE);
+    }
+
+    public void testGetMergeBuilder_returnsNewBuilder() {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+                new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        SparseTokensFieldMapper.Builder mergeBuilder = (SparseTokensFieldMapper.Builder) mapper.getMergeBuilder();
+
+        assertNotNull(mergeBuilder);
+        assertEquals(mapper.simpleName(), mergeBuilder.name());
+    }
+
+    public void testClone_createsNewInstance() {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+                new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        SparseTokensFieldMapper cloned = mapper.clone();
+
+        assertNotNull(cloned);
+        assertNotSame(mapper, cloned);
+        assertEquals(mapper.simpleName(), cloned.simpleName());
+        assertEquals(mapper.contentType(), cloned.contentType());
+        assertEquals(mapper.getSparseMethodContext(), cloned.getSparseMethodContext());
+        assertEquals(mapper.isStored(), cloned.isStored());
+        assertEquals(mapper.isHasDocValues(), cloned.isHasDocValues());
+        assertEquals(mapper.fieldType().getClass(), cloned.fieldType().getClass());
+    }
+
+    public void testFieldType_returnsCorrectType() {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+                new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        SparseTokensFieldType fieldType = mapper.fieldType();
+
+        assertNotNull(fieldType);
+        assertTrue(fieldType instanceof SparseTokensFieldType);
+    }
+
+    public void testParseCreateField_withExternalValueSet_throwsException() throws IOException {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+                new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        ParseContext context = mock(ParseContext.class);
+        when(context.externalValueSet()).thenReturn(true);
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> { mapper.parseCreateField(context); });
+        assertEquals("[sparse_tokens] fields can't be used in multi-fields", exception.getMessage());
+    }
+
+    public void testParseCreateField_withInvalidToken_throwsException() throws IOException {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+                new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        ParseContext context = mock(ParseContext.class);
+        XContentParser parser = mock(XContentParser.class);
+        when(context.externalValueSet()).thenReturn(false);
+        when(context.parser()).thenReturn(parser);
+        when(parser.currentToken()).thenReturn(XContentParser.Token.VALUE_STRING);
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> { mapper.parseCreateField(context); });
+        assertTrue(exception.getMessage().contains("fields must be json objects"));
+    }
+
+    public void testSparseTypeParser_withValidInput_returnsBuilder() throws MapperParsingException {
+        SparseTokensFieldMapper.SparseTypeParser parser = new SparseTokensFieldMapper.SparseTypeParser();
+        Map<String, Object> node = new HashMap<>();
+        Map<String, Object> method = new HashMap<>();
+        method.put(NAME_FIELD, SEISMIC);
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SUMMARY_PRUNE_RATIO_FIELD, 0.5f);
+        method.put(PARAMETERS_FIELD, parameters);
+        node.put("method", method);
+
+        SparseTokensFieldMapper.Builder result = (SparseTokensFieldMapper.Builder) parser.parse(
+                "test_field",
+                node,
+                mock(Mapper.TypeParser.ParserContext.class)
+        );
+
+        assertNotNull(result);
+        assertEquals("test_field", result.name());
+    }
+
+    public void testSparseTypeParser_withoutMethod_throwsException() {
+        SparseTokensFieldMapper.SparseTypeParser parser = new SparseTokensFieldMapper.SparseTypeParser();
+        Map<String, Object> node = new HashMap<>();
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> {
+            parser.parse("test_field", node, mock(Mapper.TypeParser.ParserContext.class));
+        });
+        assertTrue(exception.getMessage().contains("requires [method] parameter"));
+    }
+
+    public void testSparseTypeParser_withNullMethodName_throwsException() {
+        // This test shows that line 252 of SparseTokensFieldMapper.java could never reach
+        SparseTokensFieldMapper.SparseTypeParser parser = new SparseTokensFieldMapper.SparseTypeParser();
+        Map<String, Object> node = new HashMap<>();
+        Map<String, Object> method = new HashMap<>();
+        method.put(NAME_FIELD, null); // null name
+        node.put("method", method);
+
+        NullPointerException exception = expectThrows(NullPointerException.class, () -> {
+            parser.parse("test_field", node, mock(Mapper.TypeParser.ParserContext.class));
+        });
+        assertTrue(exception.getMessage().contains("Cannot invoke \"String.isEmpty()\""));
+    }
+
+    public void testSparseTypeParser_withoutMethodName_throwsException() {
+        SparseTokensFieldMapper.SparseTypeParser parser = new SparseTokensFieldMapper.SparseTypeParser();
+        Map<String, Object> node = new HashMap<>();
+        Map<String, Object> method = new HashMap<>();
+        node.put("method", method);
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> {
+            parser.parse("test_field", node, mock(Mapper.TypeParser.ParserContext.class));
+        });
+        assertTrue(exception.getMessage().contains("name needs to be set"));
+    }
+
+    public void testSparseTypeParser_withUnsupportedMethod_throwsException() {
+        SparseTokensFieldMapper.SparseTypeParser parser = new SparseTokensFieldMapper.SparseTypeParser();
+        Map<String, Object> node = new HashMap<>();
+        Map<String, Object> method = new HashMap<>();
+        method.put(NAME_FIELD, "unsupported_method");
+        node.put("method", method);
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> {
+            parser.parse("test_field", node, mock(Mapper.TypeParser.ParserContext.class));
+        });
+        assertTrue(exception.getMessage().contains("is not supported"));
+    }
+
+    public void testSparseTypeParser_withInvalidParameters_throwsException() {
+        SparseTokensFieldMapper.SparseTypeParser parser = new SparseTokensFieldMapper.SparseTypeParser();
+        Map<String, Object> node = new HashMap<>();
+        Map<String, Object> method = new HashMap<>();
+        method.put(NAME_FIELD, SEISMIC);
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SUMMARY_PRUNE_RATIO_FIELD, -1.0f);
+        method.put(PARAMETERS_FIELD, parameters);
+        node.put("method", method);
+
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> {
+            parser.parse("test_field", node, mock(Mapper.TypeParser.ParserContext.class));
+        });
+        assertTrue(exception.getMessage().contains("Validation Failed"));
+    }
+
+    public void testDefaults_fieldTypeAttributes() {
+        Map<String, String> fieldTypeAttrs = SparseTokensFieldMapper.Defaults.FIELD_TYPE.getAttributes();
+        assertTrue(fieldTypeAttrs.containsKey("sparse_tokens_field"));
+        assertEquals("true", fieldTypeAttrs.get("sparse_tokens_field"));
+
+        Map<String, String> tokenFieldTypeAttrs = SparseTokensFieldMapper.Defaults.TOKEN_FIELD_TYPE.getAttributes();
+        assertTrue(tokenFieldTypeAttrs.containsKey("sparse_tokens_field"));
+        assertEquals("true", tokenFieldTypeAttrs.get("sparse_tokens_field"));
+    }
+
+    public void testBuilder_getParameters_returnsCorrectParameters() {
+        assertEquals(3, builder.getParameters().size());
+    }
+
+    public void testParseCreateField_withValidJsonObject_parsesSuccessfully() throws IOException {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+                new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        ParseContext context = mock(ParseContext.class);
+        XContentParser parser = mock(XContentParser.class);
+        ParseContext.Document doc = mock(ParseContext.Document.class);
+
+        when(context.externalValueSet()).thenReturn(false);
+        when(context.parser()).thenReturn(parser);
+        when(context.doc()).thenReturn(doc);
+        when(parser.currentToken()).thenReturn(XContentParser.Token.START_OBJECT);
+        when(parser.nextToken()).thenReturn(XContentParser.Token.FIELD_NAME)
+                .thenReturn(XContentParser.Token.VALUE_NUMBER)
+                .thenReturn(XContentParser.Token.END_OBJECT);
+        when(parser.currentName()).thenReturn("feature1");
+        when(parser.floatValue(true)).thenReturn(0.5f);
+        when(doc.getByKey(any())).thenReturn(null);
+
+        mapper.parseCreateField(context);
+
+        verify(doc, times(1)).add(any()); // Only SparseTokensField is added to doc
+        verify(doc, times(1)).addWithKey(any(), any()); // FeatureField is added with key
+    }
+
+    public void testParseCreateField_withNullValue_ignoresFeature() throws IOException {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+                new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        ParseContext context = mock(ParseContext.class);
+        XContentParser parser = mock(XContentParser.class);
+        ParseContext.Document doc = mock(ParseContext.Document.class);
+
+        when(context.externalValueSet()).thenReturn(false);
+        when(context.parser()).thenReturn(parser);
+        when(context.doc()).thenReturn(doc);
+        when(parser.currentToken()).thenReturn(XContentParser.Token.START_OBJECT);
+        when(parser.nextToken()).thenReturn(XContentParser.Token.FIELD_NAME)
+                .thenReturn(XContentParser.Token.VALUE_NULL)
+                .thenReturn(XContentParser.Token.END_OBJECT);
+        when(parser.currentName()).thenReturn("feature1");
+
+        mapper.parseCreateField(context);
+
+        verify(doc, times(1)).add(any()); // Only SparseTokensField
+    }
+
+    public void testParseCreateField_withDuplicateFeature_throwsException() throws IOException {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+                new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        ParseContext context = mock(ParseContext.class);
+        XContentParser parser = mock(XContentParser.class);
+        ParseContext.Document doc = mock(ParseContext.Document.class);
+
+        when(context.externalValueSet()).thenReturn(false);
+        when(context.parser()).thenReturn(parser);
+        when(context.doc()).thenReturn(doc);
+        when(parser.currentToken()).thenReturn(XContentParser.Token.START_OBJECT);
+        when(parser.nextToken()).thenReturn(XContentParser.Token.FIELD_NAME).thenReturn(XContentParser.Token.VALUE_NUMBER);
+        when(parser.currentName()).thenReturn("feature1");
+        when(parser.floatValue(true)).thenReturn(0.5f);
+        when(doc.getByKey(any())).thenReturn(mock(org.apache.lucene.document.Field.class));
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> { mapper.parseCreateField(context); });
+        assertTrue(exception.getMessage().contains("do not support indexing multiple values"));
+    }
+
+    public void testParseCreateField_withInvalidTokenType_throwsException() throws IOException {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+                new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        ParseContext context = mock(ParseContext.class);
+        XContentParser parser = mock(XContentParser.class);
+        ParseContext.Document doc = mock(ParseContext.Document.class);
+
+        when(context.externalValueSet()).thenReturn(false);
+        when(context.parser()).thenReturn(parser);
+        when(context.doc()).thenReturn(doc);
+        when(parser.currentToken()).thenReturn(XContentParser.Token.START_OBJECT);
+        when(parser.nextToken()).thenReturn(XContentParser.Token.FIELD_NAME).thenReturn(XContentParser.Token.START_ARRAY);
+        when(parser.currentName()).thenReturn("feature1");
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> { mapper.parseCreateField(context); });
+        assertTrue(exception.getMessage().contains("got unexpected token"));
+    }
+
+    public void testSparseMethodContextSerialization_withValidContext_serializesCorrectly() throws Exception {
+        builder.sparseMethodContext.setValue(sparseMethodContext);
+        SparseTokensFieldMapper mapper = (SparseTokensFieldMapper) builder.build(
+                new ParametrizedFieldMapper.BuilderContext(testsPrepareUtils.prepareIndexSettings(), testsPrepareUtils.prepareContentPath())
+        );
+
+        // Use XContentFactory to create a real XContentBuilder
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
+        xContentBuilder.startObject();
+
+        // This will trigger the serializer code: b.startObject(n); v.toXContent(b, ToXContent.EMPTY_PARAMS); b.endObject();
+        mapper.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
+
+        xContentBuilder.endObject();
+        String result = xContentBuilder.toString();
+
+        // Verify the serialization contains the method object
+        assertTrue(result.contains("method"));
+        assertTrue(result.contains(SEISMIC));
+    }
+
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldTypeTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldTypeTests.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.mapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.search.lookup.SearchLookup;
+
+import static org.mockito.Mockito.mock;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SUMMARY_PRUNE_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.N_POSTINGS_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.CLUSTER_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.ALGO_TRIGGER_DOC_COUNT_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.NAME_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.PARAMETERS_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SEISMIC;
+
+public class SparseTokensFieldTypeTests extends AbstractSparseTestBase {
+    private SparseTokensFieldType fieldType;
+    private SparseMethodContext sparseMethodContext;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SUMMARY_PRUNE_RATIO_FIELD, 0.5f);
+        parameters.put(N_POSTINGS_FIELD, 10);
+        parameters.put(CLUSTER_RATIO_FIELD, 0.3f);
+        parameters.put(ALGO_TRIGGER_DOC_COUNT_FIELD, 100);
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, SEISMIC);
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        sparseMethodContext = SparseMethodContext.parse(methodMap);
+    }
+
+    public void testConstructor_withValidParameters_createsFieldType() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
+        assertNotNull(fieldType);
+        assertEquals("test_field", fieldType.name());
+        assertEquals(sparseMethodContext, fieldType.getSparseMethodContext());
+        assertFalse(fieldType.isStored());
+        assertTrue(fieldType.isHasDocValues());
+    }
+
+    public void testConstructor_withStoredTrue_setsStoredCorrectly() {
+        SparseTokensFieldType storedFieldType = new SparseTokensFieldType("stored_field", sparseMethodContext, true, false);
+
+        assertTrue(storedFieldType.isStored());
+        assertFalse(storedFieldType.isHasDocValues());
+    }
+
+    public void testTypeName_returnsCorrectType() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
+        assertEquals("sparse_tokens", fieldType.typeName());
+    }
+
+    public void testValueFetcher_withNullFormat_returnsSourceValueFetcher() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
+        QueryShardContext context = mock(QueryShardContext.class);
+        SearchLookup searchLookup = mock(SearchLookup.class);
+
+        assertNotNull(fieldType.valueFetcher(context, searchLookup, null));
+    }
+
+    public void testValueFetcher_withFormat_throwsException() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
+        QueryShardContext context = mock(QueryShardContext.class);
+        SearchLookup searchLookup = mock(SearchLookup.class);
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> {
+            fieldType.valueFetcher(context, searchLookup, "format");
+        });
+        assertTrue(exception.getMessage().contains("doesn't support formats"));
+    }
+
+    public void testTermQuery_throwsIllegalArgumentException() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
+        QueryShardContext context = mock(QueryShardContext.class);
+
+        IllegalArgumentException exception = expectThrows(
+                IllegalArgumentException.class,
+                () -> { fieldType.termQuery("test_value", context); }
+        );
+        assertTrue(exception.getMessage().contains("Queries on [sparse_tokens] fields are not supported"));
+    }
+
+    public void testExistsQuery_throwsIllegalArgumentException() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
+        QueryShardContext context = mock(QueryShardContext.class);
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> { fieldType.existsQuery(context); });
+        assertTrue(exception.getMessage().contains("[sparse_tokens] fields do not support [exists] queries"));
+    }
+
+    public void testFielddataBuilder_throwsIllegalArgumentException() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> {
+            fieldType.fielddataBuilder("test_index", () -> mock(SearchLookup.class));
+        });
+        assertTrue(exception.getMessage().contains("[sparse_tokens] fields do not support sorting, scripting or aggregating"));
+    }
+
+    public void testGetters_returnCorrectValues() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
+        assertEquals(sparseMethodContext, fieldType.getSparseMethodContext());
+        assertFalse(fieldType.isStored());
+        assertTrue(fieldType.isHasDocValues());
+    }
+
+    public void testConstructor_withNullSparseMethodContext_createsFieldType() {
+        SparseTokensFieldType nullContextFieldType = new SparseTokensFieldType("null_context_field", null, true, false);
+
+        assertNotNull(nullContextFieldType);
+        assertEquals("null_context_field", nullContextFieldType.name());
+        assertNull(nullContextFieldType.getSparseMethodContext());
+        assertTrue(nullContextFieldType.isStored());
+        assertFalse(nullContextFieldType.isHasDocValues());
+    }
+
+    public void testTermQuery_withDifferentValueTypes_throwsException() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
+        QueryShardContext context = mock(QueryShardContext.class);
+
+        // Test with different value types
+        IllegalArgumentException stringException = expectThrows(IllegalArgumentException.class, () -> {
+            fieldType.termQuery("string_value", context);
+        });
+        assertTrue(stringException.getMessage().contains("Queries on [sparse_tokens] fields are not supported"));
+
+        IllegalArgumentException intException = expectThrows(IllegalArgumentException.class, () -> { fieldType.termQuery(123, context); });
+        assertTrue(intException.getMessage().contains("Queries on [sparse_tokens] fields are not supported"));
+
+        IllegalArgumentException nullException = expectThrows(
+                IllegalArgumentException.class,
+                () -> { fieldType.termQuery(null, context); }
+        );
+        assertTrue(nullException.getMessage().contains("Queries on [sparse_tokens] fields are not supported"));
+    }
+
+    public void testFieldTypeInheritance_extendsCorrectClass() {
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
+        assertTrue(fieldType instanceof org.opensearch.index.mapper.MappedFieldType);
+    }
+
+    public void testFieldTypeProperties_inheritedFromParent() {
+        // Test inherited properties from MappedFieldType
+        fieldType = new SparseTokensFieldType("test_field", sparseMethodContext, false, true);
+        assertEquals("test_field", fieldType.name());
+        assertFalse(fieldType.isSearchable()); // Set to false in constructor
+        assertFalse(fieldType.isStored()); // Our stored parameter
+        assertTrue(fieldType.hasDocValues()); // Our hasDocValues parameter
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/testsPrepareUtils.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/testsPrepareUtils.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.DocValuesSkipIndexType;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.IndexableFieldType;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.Version;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.mapper.ContentPath;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.Executors;
+
+public class testsPrepareUtils {
+
+    private final String fieldName = "test_field";
+
+    public FieldInfo prepareKeyFieldInfo() {
+
+        // Create a FieldInfo object
+        FieldInfo keyFieldInfo = new FieldInfo(
+                fieldName,                     // name
+                0,                             // number
+                false,                         // storeTermVector
+                false,                         // omitNorms
+                false,                         // storePayloads
+                IndexOptions.DOCS,             // indexOptions
+                DocValuesType.BINARY,          // docValuesType
+                DocValuesSkipIndexType.NONE,   // docValuesSkipIndex
+                -1,                            // dvGen
+                new HashMap<>(),               // attributes
+                0,                             // pointDimensionCount
+                0,                             // pointIndexDimensionCount
+                0,                             // pointNumBytes
+                0,                             // vectorDimension
+                VectorEncoding.FLOAT32,        // vectorEncoding
+                VectorSimilarityFunction.EUCLIDEAN, // vectorSimilarityFunction
+                false,                         // softDeletesField
+                false                          // isParentField
+        );
+        return keyFieldInfo;
+    }
+
+    public static SegmentInfo prepareSegmentInfo() {
+        MergeState.DocMap[] docMaps = new MergeState.DocMap[1];
+        docMaps[0] = docID -> docID;
+        Directory dir = new ByteBuffersDirectory();
+        byte[] id = new byte[16];
+        for (int i = 0; i < id.length; i++) {
+            id[i] = (byte) i;
+        }
+
+        SegmentInfo segmentInfo = new SegmentInfo(
+                dir,                           // directory
+                Version.LATEST,                // version
+                Version.LATEST,                // minVersion
+                "_test_segment",               // name
+                10,                            // maxDoc
+                false,                         // isCompoundFile
+                false,                         // hasBlocks
+                Codec.getDefault(),            // codec
+                Collections.emptyMap(),        // diagnostics
+                id,                            // id
+                Collections.emptyMap(),        // attributes
+                null                           // indexSort
+        );
+        return segmentInfo;
+    }
+
+    public static BinaryDocValues prepareBinaryDocValues() {
+        final BytesRef value = new BytesRef(new byte[] { 1, 2, 3, 4 });
+        BinaryDocValues binaryDocValues = new BinaryDocValues() {
+            private int docID = -1;
+
+            @Override
+            public int docID() {
+                return docID;
+            }
+
+            @Override
+            public int nextDoc() {
+                if (docID < 9) {
+                    docID++;
+                    return docID;
+                }
+                return NO_MORE_DOCS;
+            }
+
+            @Override
+            public int advance(int target) {
+                if (docID < target && target <= 9) {
+                    docID = target;
+                    return docID;
+                }
+                return NO_MORE_DOCS;
+            }
+
+            @Override
+            public long cost() {
+                return 10;
+            }
+
+            @Override
+            public BytesRef binaryValue() {
+                return value;
+            }
+
+            @Override
+            public boolean advanceExact(int target) throws IOException {
+                if (target <= 9) {
+                    docID = target;
+                    return true;
+                }
+                return false;
+            }
+        };
+        return binaryDocValues;
+    }
+
+    public DocValuesProducer prepareDocValuesProducer(BinaryDocValues binaryDocValues) {
+        DocValuesProducer docValuesProducer = new DocValuesProducer() {
+            @Override
+            public NumericDocValues getNumeric(FieldInfo field) {
+                return null;
+            }
+
+            @Override
+            public BinaryDocValues getBinary(FieldInfo field) {
+                if (field.name.equals(fieldName)) {
+                    return binaryDocValues;
+                }
+                return null;
+            }
+
+            @Override
+            public SortedDocValues getSorted(FieldInfo field) {
+                return null;
+            }
+
+            @Override
+            public SortedNumericDocValues getSortedNumeric(FieldInfo field) {
+                return null;
+            }
+
+            @Override
+            public SortedSetDocValues getSortedSet(FieldInfo field) {
+                return null;
+            }
+
+            @Override
+            public void checkIntegrity() {}
+
+            @Override
+            public void close() {}
+
+            @Override
+            public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
+                return null;
+            }
+        };
+        return docValuesProducer;
+    }
+
+    public FieldsProducer prepareFieldsProducer() {
+        FieldsProducer fieldsProducer = new FieldsProducer() {
+            @Override
+            public Iterator<String> iterator() {
+                return Collections.singleton(fieldName).iterator();
+            }
+
+            @Override
+            public Terms terms(String field) {
+                return null;
+            }
+
+            @Override
+            public int size() {
+                return 1;
+            }
+
+            @Override
+            public void checkIntegrity() {}
+
+            @Override
+            public void close() {}
+        };
+        return fieldsProducer;
+    }
+
+    public MergeState prepareMergeState(boolean isEmptyMaxDocs) {
+        MergeState.DocMap[] docMaps = new MergeState.DocMap[1];
+        docMaps[0] = docID -> docID;
+        SegmentInfo segmentInfo = prepareSegmentInfo();
+
+        int[] maxDocs = new int[] { 10 };
+        if (isEmptyMaxDocs) {
+            maxDocs = new int[] { 0 };
+        }
+
+        // Create a FieldInfo object
+        FieldInfo keyFieldInfo = prepareKeyFieldInfo();
+
+        // Create a real BinaryDocValues object
+        BinaryDocValues binaryDocValues = prepareBinaryDocValues();
+
+        // Create a DocValuesProducer
+        DocValuesProducer docValuesProducer = prepareDocValuesProducer(binaryDocValues);
+
+        DocValuesProducer[] docValuesProducers = new DocValuesProducer[1];
+        docValuesProducers[0] = docValuesProducer;
+
+        // Create FieldInfos, like an array of FieldInfo
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { keyFieldInfo });
+        FieldInfos[] fieldInfosArray = new FieldInfos[1];
+        fieldInfosArray[0] = fieldInfos;
+
+        // Create FieldsProducer
+        FieldsProducer fieldsProducer = prepareFieldsProducer();
+
+        FieldsProducer[] fieldsProducers = new FieldsProducer[1];
+        fieldsProducers[0] = fieldsProducer;
+
+        // Create MergeState
+        MergeState mergeState = new MergeState(
+                docMaps,
+                segmentInfo,
+                fieldInfos,                // mergeFieldInfos
+                null,                      // storedFieldsReaders
+                null,                      // termVectorsReaders
+                null,                      // normsProducers
+                docValuesProducers,        // docValuesProducers
+                fieldInfosArray,           // fieldInfos
+                null,                      // liveDocs
+                fieldsProducers,           // fieldsProducers
+                null,                      // pointsReaders
+                null,                      // knnVectorsReaders
+                maxDocs,
+                InfoStream.getDefault(),
+                Executors.newSingleThreadExecutor(),
+                false                      // needsIndexSort
+        );
+        return mergeState;
+    }
+
+    public static IndexableFieldType prepareMockIndexableFieldType() {
+        return new IndexableFieldType() {
+            @Override
+            public boolean stored() {
+                return false;
+            }
+
+            @Override
+            public boolean tokenized() {
+                return false;
+            }
+
+            @Override
+            public boolean storeTermVectors() {
+                return false;
+            }
+
+            @Override
+            public boolean storeTermVectorOffsets() {
+                return false;
+            }
+
+            @Override
+            public boolean storeTermVectorPositions() {
+                return false;
+            }
+
+            @Override
+            public boolean storeTermVectorPayloads() {
+                return false;
+            }
+
+            @Override
+            public boolean omitNorms() {
+                return false;
+            }
+
+            @Override
+            public IndexOptions indexOptions() {
+                return IndexOptions.DOCS_AND_FREQS;
+            }
+
+            @Override
+            public DocValuesType docValuesType() {
+                return DocValuesType.NUMERIC;
+            }
+
+            @Override
+            public DocValuesSkipIndexType docValuesSkipIndexType() {
+                return DocValuesSkipIndexType.NONE;
+            }
+
+            @Override
+            public Map<String, String> getAttributes() {
+                return new HashMap<>();
+            }
+
+            @Override
+            public int pointDimensionCount() {
+                return 0;
+            }
+
+            @Override
+            public int pointIndexDimensionCount() {
+                return 0;
+            }
+
+            @Override
+            public int pointNumBytes() {
+                return 0;
+            }
+
+            @Override
+            public int vectorDimension() {
+                return 0;
+            }
+
+            @Override
+            public VectorEncoding vectorEncoding() {
+                return VectorEncoding.FLOAT32;
+            }
+
+            @Override
+            public VectorSimilarityFunction vectorSimilarityFunction() {
+                return VectorSimilarityFunction.EUCLIDEAN;
+            }
+        };
+    }
+
+    public static Settings prepareIndexSettings() {
+        return Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0).build();
+    }
+
+    public static ContentPath prepareContentPath() {
+        return new ContentPath();
+    }
+}


### PR DESCRIPTION
### Description
This PR contains developed unit tests up to July 14 2025. It mainly focuses on `org.opensearch.neuralsearch.sparse.algorithm` and `org.opensearch.neuralsearch.sparse.mapper`. Certain classes in the other package are also involved as they are high-dependency classes. In addition, a `org.opensearch.neuralsearch.sparse.testsPrepareUtils` is also created inside `tests` because it could provide some essential objects needed during tests.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
