### PR TITLE
Fix: Low recall when using combined two-phase and Sesimic

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
@@ -453,7 +453,7 @@ public class NeuralSparseQueryBuilder extends AbstractQueryBuilder<NeuralSparseQ
         if (Objects.isNull(queryTokensSupplier) != Objects.isNull(obj.queryTokensSupplier)) {
             return false;
         }
-        if (Objects.isNull(originalTokensSupplier) != Objects.isNull(obj.originalTokensSupplier)) {
+        if (Objects.isNull(twoPhaseTokensSupplier) != Objects.isNull(obj.twoPhaseTokensSupplier)) {
             return false;
         }
         if (Objects.isNull(sparseAnnQueryBuilder) != Objects.isNull(obj.sparseAnnQueryBuilder)) {


### PR DESCRIPTION
### Description
The root cause for low recall is, after the two-phase prune, the passed query tokens towards the Seismic query will also be cut. This PR fixes this bug by keeping original query tokens.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
