### PR TITLE
[Unit Tests] InMemoryKey

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/common/InMemoryKey.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/common/InMemoryKey.java
@@ -5,6 +5,7 @@
 package org.opensearch.neuralsearch.sparse.common;
 
 import lombok.EqualsAndHashCode;
+import lombok.NonNull;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.SegmentInfo;
 
@@ -18,12 +19,12 @@ public class InMemoryKey {
         private final SegmentInfo segmentInfo;
         private final String field;
 
-        public IndexKey(SegmentInfo segmentInfo, FieldInfo fieldInfo) {
+        public IndexKey(@NonNull SegmentInfo segmentInfo, @NonNull FieldInfo fieldInfo) {
             this.segmentInfo = segmentInfo;
             this.field = fieldInfo.name;
         }
 
-        public IndexKey(SegmentInfo segmentInfo, String fieldName) {
+        public IndexKey(@NonNull SegmentInfo segmentInfo, @NonNull String fieldName) {
             this.segmentInfo = segmentInfo;
             this.field = fieldName;
         }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/common/InMemoryKeyTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/common/InMemoryKeyTests.java
@@ -6,14 +6,26 @@ package org.opensearch.neuralsearch.sparse.common;
 
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.SegmentInfo;
+import org.junit.Before;
 import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
 import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
 
 public class InMemoryKeyTests extends AbstractSparseTestBase {
 
+    private static SegmentInfo segmentInfo;
+    private static FieldInfo fieldInfo;
+    private static String fieldName;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+        fieldInfo = TestsPrepareUtils.prepareKeyFieldInfo();
+        fieldName = "test_field";
+    }
+
     public void testIndexKey_constructorWithFieldInfo_createsCorrectly() {
-        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
-        FieldInfo fieldInfo = TestsPrepareUtils.prepareKeyFieldInfo();
 
         InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(segmentInfo, fieldInfo);
 
@@ -21,33 +33,53 @@ public class InMemoryKeyTests extends AbstractSparseTestBase {
     }
 
     public void testIndexKey_constructorWithFieldName_createsCorrectly() {
-        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
-        String fieldName = "test_field";
 
         InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(segmentInfo, fieldName);
 
         assertNotNull("IndexKey should be created", indexKey);
     }
 
-    public void testIndexKey_constructorWithNullSegmentInfo_createsCorrectly() {
-        FieldInfo fieldInfo = TestsPrepareUtils.prepareKeyFieldInfo();
+    public void testIndexKey_constructorWithNullSegmentInfoLegalFieldInfo_createsCorrectly() {
 
-        InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(null, fieldInfo);
+        NullPointerException exception = expectThrows(NullPointerException.class, () -> {
+            InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(null, fieldInfo);
+        });
+        assertEquals("segmentInfo is marked non-null but is null", exception.getMessage());
+    }
 
-        assertNotNull("IndexKey should be created with null SegmentInfo", indexKey);
+    public void testIndexKey_constructorWithNullSegmentInfoLegalString_createsCorrectly() {
+
+        NullPointerException exception = expectThrows(NullPointerException.class, () -> {
+            InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(null, fieldName);
+        });
+        assertEquals("segmentInfo is marked non-null but is null", exception.getMessage());
     }
 
     public void testIndexKey_constructorWithNullFieldName_createsCorrectly() {
-        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
 
-        InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(segmentInfo, (String) null);
+        NullPointerException exception = expectThrows(NullPointerException.class, () -> {
+            InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(segmentInfo, (String) null);
+        });
+        assertEquals("fieldName is marked non-null but is null", exception.getMessage());
+    }
 
-        assertNotNull("IndexKey should be created with null field name", indexKey);
+    public void testIndexKey_constructorWithNullFieldInfo_createsCorrectly() {
+
+        NullPointerException exception = expectThrows(NullPointerException.class, () -> {
+            InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(segmentInfo, (FieldInfo) null);
+        });
+        assertEquals("fieldInfo is marked non-null but is null", exception.getMessage());
+    }
+
+    public void testIndexKey_constructorWithBothNullFieldInfo_createsCorrectly() {
+
+        NullPointerException exception = expectThrows(NullPointerException.class, () -> {
+            InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey((SegmentInfo) null, (FieldInfo) null);
+        });
+        assertEquals("segmentInfo is marked non-null but is null", exception.getMessage()); // Trigger first parameter NonNull check
     }
 
     public void testIndexKey_equals_withSameValues_returnsTrue() {
-        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
-        String fieldName = "test_field";
 
         InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(segmentInfo, fieldName);
         InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(segmentInfo, fieldName);
@@ -58,7 +90,6 @@ public class InMemoryKeyTests extends AbstractSparseTestBase {
     public void testIndexKey_equals_withDifferentSegmentInfo_returnsFalse() {
         SegmentInfo segmentInfo1 = TestsPrepareUtils.prepareSegmentInfo();
         SegmentInfo segmentInfo2 = TestsPrepareUtils.prepareSegmentInfo();
-        String fieldName = "test_field";
 
         InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(segmentInfo1, fieldName);
         InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(segmentInfo2, fieldName);
@@ -67,7 +98,6 @@ public class InMemoryKeyTests extends AbstractSparseTestBase {
     }
 
     public void testIndexKey_equals_withDifferentFieldName_returnsFalse() {
-        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
 
         InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(segmentInfo, "field1");
         InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(segmentInfo, "field2");
@@ -76,29 +106,24 @@ public class InMemoryKeyTests extends AbstractSparseTestBase {
     }
 
     public void testIndexKey_equals_withSameInstance_returnsTrue() {
-        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
         InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(segmentInfo, "test_field");
 
         assertEquals("IndexKey should equal itself", indexKey, indexKey);
     }
 
     public void testIndexKey_equals_withNull_returnsFalse() {
-        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
         InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(segmentInfo, "test_field");
 
         assertNotEquals("IndexKey should not equal null", indexKey, null);
     }
 
     public void testIndexKey_equals_withDifferentClass_returnsFalse() {
-        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
         InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(segmentInfo, "test_field");
 
         assertNotEquals("IndexKey should not equal different class", indexKey, "string");
     }
 
     public void testIndexKey_hashCode_withSameValues_returnsSameHashCode() {
-        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
-        String fieldName = "test_field";
 
         InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(segmentInfo, fieldName);
         InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(segmentInfo, fieldName);
@@ -107,7 +132,6 @@ public class InMemoryKeyTests extends AbstractSparseTestBase {
     }
 
     public void testIndexKey_hashCode_withDifferentValues_returnsDifferentHashCode() {
-        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
 
         InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(segmentInfo, "field1");
         InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(segmentInfo, "field2");
@@ -116,38 +140,11 @@ public class InMemoryKeyTests extends AbstractSparseTestBase {
     }
 
     public void testIndexKey_constructorWithFieldInfo_extractsFieldName() {
-        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
-        FieldInfo fieldInfo = TestsPrepareUtils.prepareKeyFieldInfo();
 
         InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(segmentInfo, fieldInfo);
         InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(segmentInfo, "test_field");
 
         assertEquals("IndexKey created with FieldInfo should equal IndexKey created with field name", indexKey1, indexKey2);
-    }
-
-    public void testIndexKey_withNullValues_handlesEqualsCorrectly() {
-        InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(null, (String) null);
-        InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(null, (String) null);
-
-        assertEquals("IndexKeys with null values should be equal", indexKey1, indexKey2);
-    }
-
-    public void testIndexKey_withNullValues_handlesHashCodeCorrectly() {
-        InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(null, (String) null);
-        InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(null, (String) null);
-
-        assertEquals("IndexKeys with null values should have same hash code", indexKey1.hashCode(), indexKey2.hashCode());
-    }
-
-    public void testIndexKey_mixedNullValues_handlesCorrectly() {
-        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
-
-        InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(null, "field");
-        InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(segmentInfo, (String) null);
-        InMemoryKey.IndexKey indexKey3 = new InMemoryKey.IndexKey(null, "field");
-
-        assertEquals("IndexKeys with same null/non-null pattern should be equal", indexKey1, indexKey3);
-        assertNotEquals("IndexKeys with different null patterns should not be equal", indexKey1, indexKey2);
     }
 
     public void testInMemoryKey_canBeInstantiated() {

--- a/src/test/java/org/opensearch/neuralsearch/sparse/common/InMemoryKeyTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/common/InMemoryKeyTests.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.common;
+
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.SegmentInfo;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
+
+public class InMemoryKeyTests extends AbstractSparseTestBase {
+
+    public void testIndexKey_constructorWithFieldInfo_createsCorrectly() {
+        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+        FieldInfo fieldInfo = TestsPrepareUtils.prepareKeyFieldInfo();
+
+        InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(segmentInfo, fieldInfo);
+
+        assertNotNull("IndexKey should be created", indexKey);
+    }
+
+    public void testIndexKey_constructorWithFieldName_createsCorrectly() {
+        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+        String fieldName = "test_field";
+
+        InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(segmentInfo, fieldName);
+
+        assertNotNull("IndexKey should be created", indexKey);
+    }
+
+    public void testIndexKey_constructorWithNullSegmentInfo_createsCorrectly() {
+        FieldInfo fieldInfo = TestsPrepareUtils.prepareKeyFieldInfo();
+
+        InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(null, fieldInfo);
+
+        assertNotNull("IndexKey should be created with null SegmentInfo", indexKey);
+    }
+
+    public void testIndexKey_constructorWithNullFieldName_createsCorrectly() {
+        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+
+        InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(segmentInfo, (String) null);
+
+        assertNotNull("IndexKey should be created with null field name", indexKey);
+    }
+
+    public void testIndexKey_equals_withSameValues_returnsTrue() {
+        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+        String fieldName = "test_field";
+
+        InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(segmentInfo, fieldName);
+        InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(segmentInfo, fieldName);
+
+        assertEquals("IndexKeys with same values should be equal", indexKey1, indexKey2);
+    }
+
+    public void testIndexKey_equals_withDifferentSegmentInfo_returnsFalse() {
+        SegmentInfo segmentInfo1 = TestsPrepareUtils.prepareSegmentInfo();
+        SegmentInfo segmentInfo2 = TestsPrepareUtils.prepareSegmentInfo();
+        String fieldName = "test_field";
+
+        InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(segmentInfo1, fieldName);
+        InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(segmentInfo2, fieldName);
+
+        assertNotEquals("IndexKeys with different SegmentInfo should not be equal", indexKey1, indexKey2);
+    }
+
+    public void testIndexKey_equals_withDifferentFieldName_returnsFalse() {
+        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+
+        InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(segmentInfo, "field1");
+        InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(segmentInfo, "field2");
+
+        assertNotEquals("IndexKeys with different field names should not be equal", indexKey1, indexKey2);
+    }
+
+    public void testIndexKey_equals_withSameInstance_returnsTrue() {
+        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+        InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(segmentInfo, "test_field");
+
+        assertEquals("IndexKey should equal itself", indexKey, indexKey);
+    }
+
+    public void testIndexKey_equals_withNull_returnsFalse() {
+        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+        InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(segmentInfo, "test_field");
+
+        assertNotEquals("IndexKey should not equal null", indexKey, null);
+    }
+
+    public void testIndexKey_equals_withDifferentClass_returnsFalse() {
+        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+        InMemoryKey.IndexKey indexKey = new InMemoryKey.IndexKey(segmentInfo, "test_field");
+
+        assertNotEquals("IndexKey should not equal different class", indexKey, "string");
+    }
+
+    public void testIndexKey_hashCode_withSameValues_returnsSameHashCode() {
+        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+        String fieldName = "test_field";
+
+        InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(segmentInfo, fieldName);
+        InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(segmentInfo, fieldName);
+
+        assertEquals("IndexKeys with same values should have same hash code", indexKey1.hashCode(), indexKey2.hashCode());
+    }
+
+    public void testIndexKey_hashCode_withDifferentValues_returnsDifferentHashCode() {
+        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+
+        InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(segmentInfo, "field1");
+        InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(segmentInfo, "field2");
+
+        assertNotEquals("IndexKeys with different values should have different hash codes", indexKey1.hashCode(), indexKey2.hashCode());
+    }
+
+    public void testIndexKey_constructorWithFieldInfo_extractsFieldName() {
+        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+        FieldInfo fieldInfo = TestsPrepareUtils.prepareKeyFieldInfo();
+
+        InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(segmentInfo, fieldInfo);
+        InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(segmentInfo, "test_field");
+
+        assertEquals("IndexKey created with FieldInfo should equal IndexKey created with field name", indexKey1, indexKey2);
+    }
+
+    public void testIndexKey_withNullValues_handlesEqualsCorrectly() {
+        InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(null, (String) null);
+        InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(null, (String) null);
+
+        assertEquals("IndexKeys with null values should be equal", indexKey1, indexKey2);
+    }
+
+    public void testIndexKey_withNullValues_handlesHashCodeCorrectly() {
+        InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(null, (String) null);
+        InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(null, (String) null);
+
+        assertEquals("IndexKeys with null values should have same hash code", indexKey1.hashCode(), indexKey2.hashCode());
+    }
+
+    public void testIndexKey_mixedNullValues_handlesCorrectly() {
+        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+
+        InMemoryKey.IndexKey indexKey1 = new InMemoryKey.IndexKey(null, "field");
+        InMemoryKey.IndexKey indexKey2 = new InMemoryKey.IndexKey(segmentInfo, (String) null);
+        InMemoryKey.IndexKey indexKey3 = new InMemoryKey.IndexKey(null, "field");
+
+        assertEquals("IndexKeys with same null/non-null pattern should be equal", indexKey1, indexKey3);
+        assertNotEquals("IndexKeys with different null patterns should not be equal", indexKey1, indexKey2);
+    }
+
+    public void testInMemoryKey_canBeInstantiated() {
+        InMemoryKey inMemoryKey = new InMemoryKey();
+        assertNotNull("InMemoryKey should be instantiable", inMemoryKey);
+    }
+}


### PR DESCRIPTION
### Description
This PR creates unit tests for `org.opensearch.neuralsearch.sparse.common.InMemoryKey` class. It achieves 100% coverage.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
