### PR TITLE
[Fix] Add try-catch in validateMethod of Seismic

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/Seismic.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/Seismic.java
@@ -35,30 +35,78 @@ public class Seismic implements SparseAlgorithm {
         final List<String> errorMessages = new ArrayList<>();
         Map<String, Object> parameters = new HashMap<>(sparseMethodContext.getMethodComponentContext().getParameters());
         if (parameters.containsKey(SUMMARY_PRUNE_RATIO_FIELD)) {
-            float summaryPruneRatio = ((Number) parameters.get(SUMMARY_PRUNE_RATIO_FIELD)).floatValue();
-            if (summaryPruneRatio <= 0 || summaryPruneRatio > 1) {
-                errorMessages.add("summary prune ratio should be in (0, 1]");
+            try {
+                Object value = parameters.get(SUMMARY_PRUNE_RATIO_FIELD);
+                float summaryPruneRatio;
+                if (value instanceof Float) {
+                    summaryPruneRatio = ((Number) value).floatValue();
+                } else if (value instanceof String) {
+                    summaryPruneRatio = Float.parseFloat((String) value);
+                } else {
+                    throw new ClassCastException();
+                }
+                if (summaryPruneRatio <= 0 || summaryPruneRatio > 1) {
+                    errorMessages.add("summary prune ratio should be in (0, 1]");
+                }
+            } catch (ClassCastException | NumberFormatException | NullPointerException e) {
+                errorMessages.add("summary prune ratio should be a valid number");
             }
             parameters.remove(SUMMARY_PRUNE_RATIO_FIELD);
         }
         if (parameters.containsKey(N_POSTINGS_FIELD)) {
-            Integer nPostings = (Integer) parameters.get(N_POSTINGS_FIELD);
-            if (nPostings <= 0) {
-                errorMessages.add("n_postings should be a positive integer");
+            try {
+                Object value = parameters.get(N_POSTINGS_FIELD);
+                Integer nPostings;
+                if (value instanceof Integer) {
+                    nPostings = (Integer) value;
+                } else if (value instanceof String) {
+                    nPostings = Integer.parseInt((String) value);
+                } else {
+                    throw new ClassCastException();
+                }
+                if (nPostings <= 0) {
+                    errorMessages.add("n_postings should be a positive integer");
+                }
+            } catch (ClassCastException | NumberFormatException | NullPointerException e) {
+                errorMessages.add("n_postings should be a valid integer");
             }
             parameters.remove(N_POSTINGS_FIELD);
         }
         if (parameters.containsKey(CLUSTER_RATIO_FIELD)) {
-            float clusterRatio = ((Number) parameters.get(CLUSTER_RATIO_FIELD)).floatValue();
-            if (clusterRatio <= 0 || clusterRatio >= 1) {
-                errorMessages.add("cluster ratio should be in (0, 1)");
+            try {
+                Object value = parameters.get(CLUSTER_RATIO_FIELD);
+                float clusterRatio;
+                if (value instanceof Float) {
+                    clusterRatio = ((Number) value).floatValue();
+                } else if (value instanceof String) {
+                    clusterRatio = Float.parseFloat((String) value);
+                } else {
+                    throw new ClassCastException();
+                }
+                if (clusterRatio <= 0 || clusterRatio >= 1) {
+                    errorMessages.add("cluster ratio should be in (0, 1)");
+                }
+            } catch (ClassCastException | NumberFormatException | NullPointerException e) {
+                errorMessages.add("cluster ratio should be a valid number");
             }
             parameters.remove(CLUSTER_RATIO_FIELD);
         }
         if (parameters.containsKey(ALGO_TRIGGER_DOC_COUNT_FIELD)) {
-            Integer algoTriggerThreshold = (Integer) parameters.get(ALGO_TRIGGER_DOC_COUNT_FIELD);
-            if (algoTriggerThreshold < 0) {
-                errorMessages.add("algo trigger doc count should be a non-negative integer");
+            try {
+                Object value = parameters.get(ALGO_TRIGGER_DOC_COUNT_FIELD);
+                Integer algoTriggerThreshold;
+                if (value instanceof Integer) {
+                    algoTriggerThreshold = (Integer) value;
+                } else if (value instanceof String) {
+                    algoTriggerThreshold = Integer.parseInt((String) value);
+                } else {
+                    throw new ClassCastException();
+                }
+                if (algoTriggerThreshold < 0) {
+                    errorMessages.add("algo trigger doc count should be a non-negative integer");
+                }
+            } catch (ClassCastException | NumberFormatException | NullPointerException e) {
+                errorMessages.add("algo trigger doc count should be a valid integer");
             }
             parameters.remove(ALGO_TRIGGER_DOC_COUNT_FIELD);
         }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/Seismic.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/Seismic.java
@@ -6,6 +6,7 @@ package org.opensearch.neuralsearch.sparse.algorithm;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.opensearch.common.ValidationException;
 import org.opensearch.neuralsearch.sparse.mapper.SparseMethodContext;
 
@@ -36,77 +37,59 @@ public class Seismic implements SparseAlgorithm {
         Map<String, Object> parameters = new HashMap<>(sparseMethodContext.getMethodComponentContext().getParameters());
         if (parameters.containsKey(SUMMARY_PRUNE_RATIO_FIELD)) {
             try {
-                Object value = parameters.get(SUMMARY_PRUNE_RATIO_FIELD);
-                float summaryPruneRatio;
-                if (value instanceof Float) {
-                    summaryPruneRatio = ((Number) value).floatValue();
-                } else if (value instanceof String) {
-                    summaryPruneRatio = Float.parseFloat((String) value);
-                } else {
-                    throw new ClassCastException();
+                String fieldValueString = parameters.get(SUMMARY_PRUNE_RATIO_FIELD).toString();
+                float summaryPruneRatio = NumberUtils.createFloat(fieldValueString);
+                if (summaryPruneRatio <= 0 || summaryPruneRatio >= 1) {
+                    errorMessages.add(String.format(Locale.ROOT, "Parameter [%s] must be in (0, 1]", SUMMARY_PRUNE_RATIO_FIELD));
                 }
-                if (summaryPruneRatio <= 0 || summaryPruneRatio > 1) {
-                    errorMessages.add("summary prune ratio should be in (0, 1]");
-                }
-            } catch (ClassCastException | NumberFormatException | NullPointerException e) {
-                errorMessages.add("summary prune ratio should be a valid number");
+            } catch (Exception e) {
+                errorMessages.add(
+                    String.format(Locale.ROOT, "Parameter [%s] must be of %s type", SUMMARY_PRUNE_RATIO_FIELD, Float.class.getName())
+                );
             }
             parameters.remove(SUMMARY_PRUNE_RATIO_FIELD);
         }
         if (parameters.containsKey(N_POSTINGS_FIELD)) {
             try {
-                Object value = parameters.get(N_POSTINGS_FIELD);
-                Integer nPostings;
-                if (value instanceof Integer) {
-                    nPostings = (Integer) value;
-                } else if (value instanceof String) {
-                    nPostings = Integer.parseInt((String) value);
-                } else {
-                    throw new ClassCastException();
-                }
+                String fieldValueString = parameters.get(N_POSTINGS_FIELD).toString();
+                int nPostings = NumberUtils.createInteger(fieldValueString);
                 if (nPostings <= 0) {
-                    errorMessages.add("n_postings should be a positive integer");
+                    errorMessages.add(String.format(Locale.ROOT, "Parameter [%s] must be a positive integer", N_POSTINGS_FIELD));
                 }
-            } catch (ClassCastException | NumberFormatException | NullPointerException e) {
-                errorMessages.add("n_postings should be a valid integer");
+            } catch (Exception e) {
+                errorMessages.add(
+                    String.format(Locale.ROOT, "Parameter [%s] must be of %s type", N_POSTINGS_FIELD, Integer.class.getName())
+                );
             }
             parameters.remove(N_POSTINGS_FIELD);
         }
         if (parameters.containsKey(CLUSTER_RATIO_FIELD)) {
             try {
-                Object value = parameters.get(CLUSTER_RATIO_FIELD);
-                float clusterRatio;
-                if (value instanceof Float) {
-                    clusterRatio = ((Number) value).floatValue();
-                } else if (value instanceof String) {
-                    clusterRatio = Float.parseFloat((String) value);
-                } else {
-                    throw new ClassCastException();
-                }
+                String fieldValueString = parameters.get(CLUSTER_RATIO_FIELD).toString();
+                float clusterRatio = NumberUtils.createFloat(fieldValueString);
                 if (clusterRatio <= 0 || clusterRatio >= 1) {
-                    errorMessages.add("cluster ratio should be in (0, 1)");
+                    errorMessages.add(String.format(Locale.ROOT, "Parameter [%s] must be in (0, 1)", CLUSTER_RATIO_FIELD));
                 }
-            } catch (ClassCastException | NumberFormatException | NullPointerException e) {
-                errorMessages.add("cluster ratio should be a valid number");
+            } catch (Exception e) {
+                errorMessages.add(
+                    String.format(Locale.ROOT, "Parameter [%s] must be of %s type", CLUSTER_RATIO_FIELD, Float.class.getName())
+                );
             }
             parameters.remove(CLUSTER_RATIO_FIELD);
         }
         if (parameters.containsKey(ALGO_TRIGGER_DOC_COUNT_FIELD)) {
             try {
-                Object value = parameters.get(ALGO_TRIGGER_DOC_COUNT_FIELD);
-                Integer algoTriggerThreshold;
-                if (value instanceof Integer) {
-                    algoTriggerThreshold = (Integer) value;
-                } else if (value instanceof String) {
-                    algoTriggerThreshold = Integer.parseInt((String) value);
-                } else {
-                    throw new ClassCastException();
-                }
+                String fieldValueString = parameters.get(ALGO_TRIGGER_DOC_COUNT_FIELD).toString();
+                int algoTriggerThreshold = NumberUtils.createInteger(fieldValueString);
                 if (algoTriggerThreshold < 0) {
-                    errorMessages.add("algo trigger doc count should be a non-negative integer");
+                    errorMessages.add(
+                        String.format(Locale.ROOT, "Parameter [%s] must be a non-Negative integer", ALGO_TRIGGER_DOC_COUNT_FIELD)
+                    );
                 }
-            } catch (ClassCastException | NumberFormatException | NullPointerException e) {
-                errorMessages.add("algo trigger doc count should be a valid integer");
+            } catch (Exception e) {
+                errorMessages.add(
+                    String.format(Locale.ROOT, "Parameter [%s] must be of %s type", ALGO_TRIGGER_DOC_COUNT_FIELD, Integer.class.getName())
+                );
             }
             parameters.remove(ALGO_TRIGGER_DOC_COUNT_FIELD);
         }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/Seismic.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/Seismic.java
@@ -39,7 +39,7 @@ public class Seismic implements SparseAlgorithm {
             try {
                 String fieldValueString = parameters.get(SUMMARY_PRUNE_RATIO_FIELD).toString();
                 float summaryPruneRatio = NumberUtils.createFloat(fieldValueString);
-                if (summaryPruneRatio <= 0 || summaryPruneRatio >= 1) {
+                if (summaryPruneRatio <= 0 || summaryPruneRatio > 1) {
                     errorMessages.add(String.format(Locale.ROOT, "Parameter [%s] must be in (0, 1]", SUMMARY_PRUNE_RATIO_FIELD));
                 }
             } catch (Exception e) {

--- a/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/SeismicTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/SeismicTests.java
@@ -5,6 +5,7 @@
 package org.opensearch.neuralsearch.sparse.algorithm;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.opensearch.common.ValidationException;
@@ -32,7 +33,8 @@ public class SeismicTests extends AbstractSparseTestBase {
         ValidationException result = Seismic.INSTANCE.validateMethod(context);
 
         assertNotNull(result);
-        assertTrue(result.validationErrors().contains("algo trigger doc count should be a non-negative integer"));
+        String expectedError = String.format(Locale.ROOT, "Parameter [%s] must be a non-Negative integer", ALGO_TRIGGER_DOC_COUNT_FIELD);
+        assertTrue(result.validationErrors().contains(expectedError));
     }
 
     public void testValidateMethod_validAlgoTriggerStringNumberDocCount() {
@@ -61,7 +63,13 @@ public class SeismicTests extends AbstractSparseTestBase {
         ValidationException result = Seismic.INSTANCE.validateMethod(context);
 
         assertNotNull(result);
-        assertTrue(result.validationErrors().contains("algo trigger doc count should be a valid integer"));
+        String expectedError = String.format(
+            Locale.ROOT,
+            "Parameter [%s] must be of %s type",
+            ALGO_TRIGGER_DOC_COUNT_FIELD,
+            Integer.class.getName()
+        );
+        assertTrue(result.validationErrors().contains(expectedError));
     }
 
     public void testValidateMethod_invalidAlgoTriggerBooleanDocCount() {
@@ -76,7 +84,13 @@ public class SeismicTests extends AbstractSparseTestBase {
         ValidationException result = Seismic.INSTANCE.validateMethod(context);
 
         assertNotNull(result);
-        assertTrue(result.validationErrors().contains("algo trigger doc count should be a valid integer"));
+        String expectedError = String.format(
+            Locale.ROOT,
+            "Parameter [%s] must be of %s type",
+            ALGO_TRIGGER_DOC_COUNT_FIELD,
+            Integer.class.getName()
+        );
+        assertTrue(result.validationErrors().contains(expectedError));
     }
 
     public void testValidateMethod_validSummaryPruneRatioStringNumberDocCount() {
@@ -105,7 +119,13 @@ public class SeismicTests extends AbstractSparseTestBase {
         ValidationException result = Seismic.INSTANCE.validateMethod(context);
 
         assertNotNull(result);
-        assertTrue(result.validationErrors().contains("summary prune ratio should be a valid number"));
+        String expectedError = String.format(
+            Locale.ROOT,
+            "Parameter [%s] must be of %s type",
+            SUMMARY_PRUNE_RATIO_FIELD,
+            Float.class.getName()
+        );
+        assertTrue(result.validationErrors().contains(expectedError));
     }
 
     public void testValidateMethod_invalidSummaryPruneRatioBooleanDocCount() {
@@ -120,7 +140,13 @@ public class SeismicTests extends AbstractSparseTestBase {
         ValidationException result = Seismic.INSTANCE.validateMethod(context);
 
         assertNotNull(result);
-        assertTrue(result.validationErrors().contains("summary prune ratio should be a valid number"));
+        String expectedError = String.format(
+            Locale.ROOT,
+            "Parameter [%s] must be of %s type",
+            SUMMARY_PRUNE_RATIO_FIELD,
+            Float.class.getName()
+        );
+        assertTrue(result.validationErrors().contains(expectedError));
     }
 
     public void testValidateMethod_validPostingFieldStringNumberDocCount() {
@@ -149,7 +175,8 @@ public class SeismicTests extends AbstractSparseTestBase {
         ValidationException result = Seismic.INSTANCE.validateMethod(context);
 
         assertNotNull(result);
-        assertTrue(result.validationErrors().contains("n_postings should be a valid integer"));
+        String expectedError = String.format(Locale.ROOT, "Parameter [%s] must be of %s type", N_POSTINGS_FIELD, Integer.class.getName());
+        assertTrue(result.validationErrors().contains(expectedError));
     }
 
     public void testValidateMethod_invalidPostingFieldBooleanDocCount() {
@@ -164,7 +191,8 @@ public class SeismicTests extends AbstractSparseTestBase {
         ValidationException result = Seismic.INSTANCE.validateMethod(context);
 
         assertNotNull(result);
-        assertTrue(result.validationErrors().contains("n_postings should be a valid integer"));
+        String expectedError = String.format(Locale.ROOT, "Parameter [%s] must be of %s type", N_POSTINGS_FIELD, Integer.class.getName());
+        assertTrue(result.validationErrors().contains(expectedError));
     }
 
     public void testValidateMethod_validClusterRatioStringNumberDocCount() {
@@ -193,7 +221,8 @@ public class SeismicTests extends AbstractSparseTestBase {
         ValidationException result = Seismic.INSTANCE.validateMethod(context);
 
         assertNotNull(result);
-        assertTrue(result.validationErrors().contains("cluster ratio should be a valid number"));
+        String expectedError = String.format(Locale.ROOT, "Parameter [%s] must be of %s type", CLUSTER_RATIO_FIELD, Float.class.getName());
+        assertTrue(result.validationErrors().contains(expectedError));
     }
 
     public void testValidateMethod_invalidClusterRatioBooleanDocCount() {
@@ -208,7 +237,8 @@ public class SeismicTests extends AbstractSparseTestBase {
         ValidationException result = Seismic.INSTANCE.validateMethod(context);
 
         assertNotNull(result);
-        assertTrue(result.validationErrors().contains("cluster ratio should be a valid number"));
+        String expectedError = String.format(Locale.ROOT, "Parameter [%s] must be of %s type", CLUSTER_RATIO_FIELD, Float.class.getName());
+        assertTrue(result.validationErrors().contains(expectedError));
     }
 
     public void testValidateMethod_invalidClusterRatio() {
@@ -223,7 +253,8 @@ public class SeismicTests extends AbstractSparseTestBase {
         ValidationException result = Seismic.INSTANCE.validateMethod(context);
 
         assertNotNull(result);
-        assertTrue(result.validationErrors().contains("cluster ratio should be in (0, 1)"));
+        String expectedError = String.format(Locale.ROOT, "Parameter [%s] must be in (0, 1)", CLUSTER_RATIO_FIELD);
+        assertTrue(result.validationErrors().contains(expectedError));
     }
 
     public void testValidateMethod_invalidNPostings() {
@@ -238,7 +269,8 @@ public class SeismicTests extends AbstractSparseTestBase {
         ValidationException result = Seismic.INSTANCE.validateMethod(context);
 
         assertNotNull(result);
-        assertTrue(result.validationErrors().contains("n_postings should be a positive integer"));
+        String expectedError = String.format(Locale.ROOT, "Parameter [%s] must be a positive integer", N_POSTINGS_FIELD);
+        assertTrue(result.validationErrors().contains(expectedError));
     }
 
     public void testValidateMethod_invalidSummaryPruneRatio() {
@@ -253,7 +285,8 @@ public class SeismicTests extends AbstractSparseTestBase {
         ValidationException result = Seismic.INSTANCE.validateMethod(context);
 
         assertNotNull(result);
-        assertTrue(result.validationErrors().contains("summary prune ratio should be in (0, 1]"));
+        String expectedError = String.format(Locale.ROOT, "Parameter [%s] must be in (0, 1]", SUMMARY_PRUNE_RATIO_FIELD);
+        assertTrue(result.validationErrors().contains(expectedError));
     }
 
     public void testValidateMethod_multipleInvalidParameters() {
@@ -270,9 +303,12 @@ public class SeismicTests extends AbstractSparseTestBase {
         ValidationException validationException = Seismic.INSTANCE.validateMethod(sparseMethodContext);
 
         assertNotNull(validationException);
-        assertTrue(validationException.validationErrors().contains("n_postings should be a positive integer"));
-        assertTrue(validationException.validationErrors().contains("cluster ratio should be in (0, 1)"));
-        assertTrue(validationException.validationErrors().contains("algo trigger doc count should be a non-negative integer"));
+        String expectedError1 = String.format(Locale.ROOT, "Parameter [%s] must be a positive integer", N_POSTINGS_FIELD);
+        String expectedError2 = String.format(Locale.ROOT, "Parameter [%s] must be in (0, 1)", CLUSTER_RATIO_FIELD);
+        String expectedError3 = String.format(Locale.ROOT, "Parameter [%s] must be a non-Negative integer", ALGO_TRIGGER_DOC_COUNT_FIELD);
+        assertTrue(validationException.validationErrors().contains(expectedError1));
+        assertTrue(validationException.validationErrors().contains(expectedError2));
+        assertTrue(validationException.validationErrors().contains(expectedError3));
     }
 
     public void testValidateMethod_unknownParameter() {
@@ -323,10 +359,14 @@ public class SeismicTests extends AbstractSparseTestBase {
         ValidationException result = Seismic.INSTANCE.validateMethod(sparseMethodContext);
 
         assertNotNull(result);
-        assertTrue(result.validationErrors().contains("summary prune ratio should be in (0, 1]"));
-        assertTrue(result.validationErrors().contains("n_postings should be a positive integer"));
-        assertTrue(result.validationErrors().contains("cluster ratio should be in (0, 1)"));
-        assertTrue(result.validationErrors().contains("algo trigger doc count should be a non-negative integer"));
+        String expectedError1 = String.format(Locale.ROOT, "Parameter [%s] must be a positive integer", N_POSTINGS_FIELD);
+        String expectedError2 = String.format(Locale.ROOT, "Parameter [%s] must be in (0, 1)", CLUSTER_RATIO_FIELD);
+        String expectedError3 = String.format(Locale.ROOT, "Parameter [%s] must be a non-Negative integer", ALGO_TRIGGER_DOC_COUNT_FIELD);
+        String expectedError4 = String.format(Locale.ROOT, "Parameter [%s] must be in (0, 1]", SUMMARY_PRUNE_RATIO_FIELD);
+        assertTrue(result.validationErrors().contains(expectedError1));
+        assertTrue(result.validationErrors().contains(expectedError2));
+        assertTrue(result.validationErrors().contains(expectedError3));
+        assertTrue(result.validationErrors().contains(expectedError4));
         assertTrue(result.validationErrors().contains("Unknown parameter 'unknown_param' found"));
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/SeismicTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/SeismicTests.java
@@ -35,6 +35,182 @@ public class SeismicTests extends AbstractSparseTestBase {
         assertTrue(result.validationErrors().contains("algo trigger doc count should be a non-negative integer"));
     }
 
+    public void testValidateMethod_validAlgoTriggerStringNumberDocCount() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(ALGO_TRIGGER_DOC_COUNT_FIELD, "12");
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNull(result);
+    }
+
+    public void testValidateMethod_invalidAlgoTriggerStringTextDocCount() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(ALGO_TRIGGER_DOC_COUNT_FIELD, "invalid number");
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNotNull(result);
+        assertTrue(result.validationErrors().contains("algo trigger doc count should be a valid integer"));
+    }
+
+    public void testValidateMethod_invalidAlgoTriggerBooleanDocCount() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(ALGO_TRIGGER_DOC_COUNT_FIELD, false);
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNotNull(result);
+        assertTrue(result.validationErrors().contains("algo trigger doc count should be a valid integer"));
+    }
+
+    public void testValidateMethod_validSummaryPruneRatioStringNumberDocCount() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SUMMARY_PRUNE_RATIO_FIELD, "0.5");
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNull(result);
+    }
+
+    public void testValidateMethod_invalidSummaryPruneRatioStringTextDocCount() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SUMMARY_PRUNE_RATIO_FIELD, "invalid number");
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNotNull(result);
+        assertTrue(result.validationErrors().contains("summary prune ratio should be a valid number"));
+    }
+
+    public void testValidateMethod_invalidSummaryPruneRatioBooleanDocCount() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SUMMARY_PRUNE_RATIO_FIELD, false);
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNotNull(result);
+        assertTrue(result.validationErrors().contains("summary prune ratio should be a valid number"));
+    }
+
+    public void testValidateMethod_validPostingFieldStringNumberDocCount() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(N_POSTINGS_FIELD, "4000");
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNull(result);
+    }
+
+    public void testValidateMethod_invalidPostingFieldStringTextDocCount() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(N_POSTINGS_FIELD, "invalid number");
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNotNull(result);
+        assertTrue(result.validationErrors().contains("n_postings should be a valid integer"));
+    }
+
+    public void testValidateMethod_invalidPostingFieldBooleanDocCount() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(N_POSTINGS_FIELD, false);
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNotNull(result);
+        assertTrue(result.validationErrors().contains("n_postings should be a valid integer"));
+    }
+
+    public void testValidateMethod_validClusterRatioStringNumberDocCount() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(CLUSTER_RATIO_FIELD, "0.5");
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNull(result);
+    }
+
+    public void testValidateMethod_invalidClusterRatioStringTextDocCount() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(CLUSTER_RATIO_FIELD, "invalid number");
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNotNull(result);
+        assertTrue(result.validationErrors().contains("cluster ratio should be a valid number"));
+    }
+
+    public void testValidateMethod_invalidClusterRatioBooleanDocCount() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(CLUSTER_RATIO_FIELD, false);
+
+        Map<String, Object> methodMap = new HashMap<>();
+        methodMap.put(NAME_FIELD, "testMethod");
+        methodMap.put(PARAMETERS_FIELD, parameters);
+        SparseMethodContext context = SparseMethodContext.parse(methodMap);
+
+        ValidationException result = Seismic.INSTANCE.validateMethod(context);
+
+        assertNotNull(result);
+        assertTrue(result.validationErrors().contains("cluster ratio should be a valid number"));
+    }
+
     public void testValidateMethod_invalidClusterRatio() {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put(CLUSTER_RATIO_FIELD, 1.0f);
@@ -83,7 +259,7 @@ public class SeismicTests extends AbstractSparseTestBase {
     public void testValidateMethod_multipleInvalidParameters() {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put(N_POSTINGS_FIELD, 0);
-        parameters.put(CLUSTER_RATIO_FIELD, 1.5f);
+        parameters.put(CLUSTER_RATIO_FIELD, -1.5f);
         parameters.put(ALGO_TRIGGER_DOC_COUNT_FIELD, -1);
 
         Map<String, Object> methodMap = new HashMap<>();


### PR DESCRIPTION
### Description
This PR adds try catch protection to `validateMethod` of `org.opensearch.neuralsearch.sparse.algorithm.Seismic`. Now, it can handle those non-numerical string and other input types instead of directly throwing exceptions. In addition, I added several unit tests to its test file, so that it can better cover current codes.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
