### PR TITLE
[Unit Tests] SparseAnnQueryBuilder

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/sparse/query/SparseAnnQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/query/SparseAnnQueryBuilderTests.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.query;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.ParsingException;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.mapper.SparseTokensFieldMapper;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+
+public class SparseAnnQueryBuilderTests extends AbstractSparseTestBase {
+    private static SparseAnnQueryBuilder queryBuilder;
+    private static Map<String, Float> queryTokens;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        queryTokens = new HashMap<>();
+        queryTokens.put("1", 0.8f);
+        queryTokens.put("2", 0.6f);
+        queryTokens.put("3", 0.4f);
+
+        queryBuilder = SparseAnnQueryBuilder.builder()
+            .fieldName("test_field")
+            .queryCut(2)
+            .k(10)
+            .heapFactor(1.5f)
+            .queryTokens(queryTokens)
+            .build();
+    }
+
+    public void testBuilder_withValidParameters_createsQueryBuilder() {
+        assertNotNull(queryBuilder);
+        assertEquals("test_field", queryBuilder.fieldName());
+        assertEquals(Integer.valueOf(2), queryBuilder.queryCut());
+        assertEquals(Integer.valueOf(10), queryBuilder.k());
+        assertEquals(Float.valueOf(1.5f), queryBuilder.heapFactor());
+        assertEquals(queryTokens, queryBuilder.queryTokens());
+    }
+
+    public void testGetWriteableName_returnsCorrectName() {
+        assertEquals("sparse_ann", queryBuilder.getWriteableName());
+    }
+
+    public void testFromXContent_withValidJson_parsesCorrectly() throws IOException {
+        String json = "{\"cut\": 5, \"k\": 20, \"heap_factor\": 2.0}";
+        XContentParser parser = createParser(json);
+        parser.nextToken();
+
+        SparseAnnQueryBuilder parsed = SparseAnnQueryBuilder.fromXContent(parser);
+
+        assertNotNull(parsed);
+        assertEquals(Integer.valueOf(5), parsed.queryCut());
+        assertEquals(Integer.valueOf(20), parsed.k());
+        assertEquals(Float.valueOf(2.0f), parsed.heapFactor());
+    }
+
+    public void testFromXContent_withInvalidField_throwsException() throws IOException {
+        String json = "{\"invalid_field\": \"value\"}";
+        XContentParser parser = createParser(json);
+        parser.nextToken();
+
+        ParsingException exception = expectThrows(ParsingException.class, () -> { SparseAnnQueryBuilder.fromXContent(parser); });
+        assertTrue(exception.getMessage().contains("unknown field [invalid_field]"));
+    }
+
+    public void testDoXContent_withAllFields_serializesCorrectly() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        queryBuilder.doXContent(builder, null);
+        builder.endObject();
+
+        String result = builder.toString();
+        assertTrue(result.contains("\"cut\":2"));
+        assertTrue(result.contains("\"k\":10"));
+        assertTrue(result.contains("\"heap_factor\":1.5"));
+    }
+
+    public void testValidateFieldType_withValidFieldType_passes() {
+        MappedFieldType fieldType = mock(MappedFieldType.class);
+        when(fieldType.typeName()).thenReturn(SparseTokensFieldMapper.CONTENT_TYPE);
+
+        SparseAnnQueryBuilder.validateFieldType(fieldType);
+    }
+
+    public void testValidateFieldType_withInvalidFieldType_throwsException() {
+        MappedFieldType fieldType = mock(MappedFieldType.class);
+        when(fieldType.typeName()).thenReturn("text");
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> {
+            SparseAnnQueryBuilder.validateFieldType(fieldType);
+        });
+        assertTrue(exception.getMessage().contains("query only works on [sparse_tokens] fields"));
+    }
+
+    public void testEquals_withSameValues_returnsTrue() {
+        SparseAnnQueryBuilder other = SparseAnnQueryBuilder.builder().queryCut(2).k(10).heapFactor(1.5f).build();
+
+        assertTrue(queryBuilder.doEquals(other));
+    }
+
+    public void testHashCode_withSameValues_returnsSameHashCode() {
+        SparseAnnQueryBuilder other = SparseAnnQueryBuilder.builder().queryCut(2).k(10).heapFactor(1.5f).build();
+
+        assertEquals(queryBuilder.doHashCode(), other.doHashCode());
+    }
+
+    public void testDoToQuery_withValidContext_returnsQuery() throws IOException {
+        QueryShardContext context = mock(QueryShardContext.class);
+        MappedFieldType fieldType = mock(MappedFieldType.class);
+        when(fieldType.typeName()).thenReturn(SparseTokensFieldMapper.CONTENT_TYPE);
+        when(context.fieldMapper("test_field")).thenReturn(fieldType);
+
+        queryBuilder.fallbackQuery(mock(org.apache.lucene.search.Query.class));
+
+        assertNotNull(queryBuilder.doToQuery(context));
+    }
+
+    private XContentParser createParser(String json) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .rawValue(new java.io.ByteArrayInputStream(json.getBytes()), XContentType.JSON);
+        return createParser(builder);
+    }
+
+    public void testStreamConstructor_readsCorrectly() throws IOException {
+        org.opensearch.core.common.io.stream.StreamInput streamInput = mock(org.opensearch.core.common.io.stream.StreamInput.class);
+        when(streamInput.readOptionalInt()).thenReturn(5, 20);
+        when(streamInput.readOptionalFloat()).thenReturn(1.5f);
+
+        SparseAnnQueryBuilder fromStream = new SparseAnnQueryBuilder(streamInput);
+
+        assertEquals(Integer.valueOf(5), fromStream.queryCut());
+        assertEquals(Integer.valueOf(20), fromStream.k());
+        assertEquals(Float.valueOf(1.5f), fromStream.heapFactor());
+    }
+
+    public void testDoWriteTo_writesCorrectly() throws IOException {
+        org.opensearch.core.common.io.stream.StreamOutput streamOutput = mock(org.opensearch.core.common.io.stream.StreamOutput.class);
+
+        queryBuilder.doWriteTo(streamOutput);
+
+        verify(streamOutput).writeOptionalInt(2);
+        verify(streamOutput).writeOptionalInt(10);
+        verify(streamOutput).writeOptionalFloat(1.5f);
+    }
+
+    public void testFromXContent_withInvalidStartToken_throwsException() throws IOException {
+        String json = "\"invalid_start\"";
+        XContentParser parser = createParser(json);
+        parser.nextToken();
+
+        ParsingException exception = expectThrows(ParsingException.class, () -> { SparseAnnQueryBuilder.fromXContent(parser); });
+        assertTrue(exception.getMessage().contains("must be an object"));
+    }
+
+    public void testEquals_withSameInstance_returnsTrue() {
+        assertTrue(queryBuilder.doEquals(queryBuilder));
+    }
+
+    public void testEquals_withNull_returnsFalse() {
+        assertFalse(queryBuilder.doEquals(null));
+    }
+
+    public void testFromXContent_withFilter_triggersFilterParsing() throws IOException {
+        String json = "{\"cut\": 3, \"filter\": {\"match_all\": {}}}";
+        XContentParser parser = createParser(json);
+        parser.nextToken();
+
+        Exception exception = expectThrows(Exception.class, () -> { SparseAnnQueryBuilder.fromXContent(parser); });
+
+        assertTrue(
+            "Should fail at QueryBuilder parsing",
+            exception.getMessage().contains("unknown query")
+                || exception.getMessage().contains("NamedObjectNotFoundException")
+                || exception.getMessage().contains("unknown named object category")
+        );
+    }
+
+    public void testFromXContent_withUnknownToken_throwsException() throws IOException {
+        String json = "{\"cut\": {\"nested\": \"object\"}}";
+        XContentParser parser = createParser(json);
+        parser.nextToken();
+
+        ParsingException exception = expectThrows(ParsingException.class, () -> { SparseAnnQueryBuilder.fromXContent(parser); });
+        assertTrue(exception.getMessage().contains("unknown token"));
+    }
+
+    public void testDoRewrite_returnsNewInstance() {
+        org.opensearch.index.query.TermQueryBuilder filter = new org.opensearch.index.query.TermQueryBuilder("status", "active");
+        queryBuilder.filter(filter);
+
+        SparseAnnQueryBuilder rewritten = (SparseAnnQueryBuilder) queryBuilder.doRewrite(null);
+
+        assertNotNull(rewritten);
+        assertNotSame(queryBuilder, rewritten);
+        assertEquals(queryBuilder.fieldName(), rewritten.fieldName());
+        assertEquals(queryBuilder.queryCut(), rewritten.queryCut());
+        assertEquals(queryBuilder.k(), rewritten.k());
+        assertEquals(queryBuilder.heapFactor(), rewritten.heapFactor());
+        assertEquals(queryBuilder.filter(), rewritten.filter());
+    }
+
+    public void testDoToQuery_withFilter_appliesFilter() throws IOException {
+        QueryShardContext context = mock(QueryShardContext.class);
+        MappedFieldType fieldType = mock(MappedFieldType.class);
+        when(fieldType.typeName()).thenReturn(SparseTokensFieldMapper.CONTENT_TYPE);
+        when(context.fieldMapper("test_field")).thenReturn(fieldType);
+
+        org.opensearch.index.query.QueryBuilder filter = mock(org.opensearch.index.query.QueryBuilder.class);
+        org.apache.lucene.search.Query filterQuery = mock(org.apache.lucene.search.Query.class);
+        when(filter.toQuery(context)).thenReturn(filterQuery);
+
+        queryBuilder.filter(filter);
+        queryBuilder.fallbackQuery(mock(org.apache.lucene.search.Query.class));
+
+        assertNotNull(queryBuilder.doToQuery(context));
+        verify(filter).toQuery(context);
+    }
+}


### PR DESCRIPTION
### Description
This PR creates unit tests for `org.opensearch.neuralsearch.sparse.query.SparseAnnQueryBuilder` class. It achieves 97% coverage, but already reached every possible branch.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
