### PR TITLE
[Unit Tests] SparseQueryWeight

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/query/SparseQueryWeight.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/query/SparseQueryWeight.java
@@ -60,6 +60,8 @@ public class SparseQueryWeight extends Weight {
                 leafReader = ((FilterLeafReader) leafReader).getDelegate();
             } else if (leafReader instanceof FilterCodecReader) {
                 leafReader = ((FilterCodecReader) leafReader).getDelegate();
+            } else {
+                break;
             }
         }
         if (!(leafReader instanceof SegmentReader)) {

--- a/src/test/java/org/opensearch/neuralsearch/sparse/TestsPrepareUtils.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/TestsPrepareUtils.java
@@ -24,6 +24,18 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.IndexableFieldType;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.index.TermVectors;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.index.LeafMetaData;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.search.KnnCollector;
+
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
@@ -33,11 +45,14 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.index.mapper.ContentPath;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.Executors;
+
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.ALGO_TRIGGER_DOC_COUNT_FIELD;
 
 public class TestsPrepareUtils {
 
@@ -365,5 +380,145 @@ public class TestsPrepareUtils {
 
     public static ContentPath prepareContentPath() {
         return new ContentPath();
+    }
+
+    public static SegmentReader prepareSegmentReader() {
+        // We can't mock SegmentReader as it's final, and we can't easily create a real one
+        // due to its complex dependencies, so we'll return null
+        return null;
+    }
+
+    public static LeafReaderContext prepareLeafReaderContext() {
+        // Create a mock LeafReader
+        LeafReader leafReader = new LeafReader() {
+            @Override
+            public Terms terms(String field) {
+                return null;
+            }
+
+            @Override
+            public NumericDocValues getNumericDocValues(String field) {
+                return null;
+            }
+
+            @Override
+            public BinaryDocValues getBinaryDocValues(String field) {
+                return null;
+            }
+
+            @Override
+            public SortedDocValues getSortedDocValues(String field) {
+                return null;
+            }
+
+            @Override
+            public SortedNumericDocValues getSortedNumericDocValues(String field) {
+                return null;
+            }
+
+            @Override
+            public SortedSetDocValues getSortedSetDocValues(String field) {
+                return null;
+            }
+
+            @Override
+            public FieldInfos getFieldInfos() {
+                FieldInfo fieldInfo = prepareKeyFieldInfo();
+                fieldInfo.putAttribute(ALGO_TRIGGER_DOC_COUNT_FIELD, "1");
+                return new FieldInfos(new FieldInfo[] { fieldInfo });
+            }
+
+            @Override
+            public Bits getLiveDocs() {
+                return null;
+            }
+
+            @Override
+            public PointValues getPointValues(String field) throws IOException {
+                return null;
+            }
+
+            @Override
+            public TermVectors termVectors() throws IOException {
+                return null;
+            }
+
+            @Override
+            public int numDocs() {
+                return 10;
+            }
+
+            @Override
+            public int maxDoc() {
+                return 10;
+            }
+
+            @Override
+            public StoredFields storedFields() throws IOException {
+                return null;
+            }
+
+            @Override
+            protected void doClose() throws IOException {
+
+            }
+
+            @Override
+            public void checkIntegrity() {}
+
+            @Override
+            public LeafMetaData getMetaData() {
+                return null;
+            }
+
+            @Override
+            public CacheHelper getCoreCacheHelper() {
+                return null;
+            }
+
+            @Override
+            public CacheHelper getReaderCacheHelper() {
+                return null;
+            }
+
+            @Override
+            public NumericDocValues getNormValues(String field) {
+                return null;
+            }
+
+            @Override
+            public DocValuesSkipper getDocValuesSkipper(String field) throws IOException {
+                return null;
+            }
+
+            @Override
+            public FloatVectorValues getFloatVectorValues(String field) throws IOException {
+                return null;
+            }
+
+            @Override
+            public ByteVectorValues getByteVectorValues(String field) throws IOException {
+                return null;
+            }
+
+            @Override
+            public void searchNearestVectors(String field, float[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
+
+            }
+
+            @Override
+            public void searchNearestVectors(String field, byte[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
+
+            }
+        };
+
+        // Use reflection to create a LeafReaderContext since the constructor is not public
+        try {
+            Constructor<LeafReaderContext> constructor = LeafReaderContext.class.getDeclaredConstructor(LeafReader.class);
+            constructor.setAccessible(true);
+            return constructor.newInstance(leafReader);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create LeafReaderContext", e);
+        }
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/query/SparseQueryWeightTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/query/SparseQueryWeightTests.java
@@ -1,0 +1,761 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.query;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.Version;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
+import org.opensearch.neuralsearch.sparse.codec.SparseVectorForwardIndex;
+import org.opensearch.neuralsearch.sparse.common.SparseVector;
+import org.opensearch.neuralsearch.sparse.common.SparseVectorReader;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.ALGO_TRIGGER_DOC_COUNT_FIELD;
+
+public class SparseQueryWeightTests extends AbstractSparseTestBase {
+
+    private static final String FIELD_NAME = "test_field";
+
+    @Mock
+    private IndexSearcher mockSearcher;
+
+    @Mock
+    private SparseQueryContext mockQueryContext;
+
+    @Mock
+    private Weight mockBooleanQueryWeight;
+
+    @Mock
+    private ScorerSupplier mockScorerSupplier;
+
+    @Mock
+    private Scorer mockScorer;
+
+    @Mock
+    private LeafCollector mockLeafCollector;
+
+    @Mock
+    private SparseVectorForwardIndex mockForwardIndex;
+
+    @Mock
+    private SparseVectorReader mockSparseReader;
+
+    private SparseVector queryVector;
+    private SparseVectorQuery sparseVectorQuery;
+    private LeafReaderContext leafReaderContext;
+    private FieldInfo fieldInfo;
+    private SegmentInfo segmentInfo;
+    private IndexReader indexReader;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        // Create query vector
+        queryVector = createVector(1, 1, 3, 2, 5, 3);
+
+        // Create a basic SparseVectorQuery
+        Query originalQuery = new MatchAllDocsQuery();
+        sparseVectorQuery = SparseVectorQuery.builder()
+            .queryVector(queryVector)
+            .queryContext(mockQueryContext)
+            .fieldName(FIELD_NAME)
+            .originalQuery(originalQuery)
+            .build();
+
+        // Set up mock searcher
+        indexReader = createTestIndexReader();
+        when(mockSearcher.getIndexReader()).thenReturn(indexReader);
+        leafReaderContext = TestsPrepareUtils.prepareLeafReaderContext();
+
+        // Set up mock boolean query weight
+        when(mockBooleanQueryWeight.scorerSupplier(any(LeafReaderContext.class))).thenReturn(mockScorerSupplier);
+        when(mockScorerSupplier.get(anyInt())).thenReturn(mockScorer);
+        when(mockScorer.iterator()).thenReturn(DocIdSetIterator.all(1));
+
+        // Mock the query context
+        when(mockQueryContext.getK()).thenReturn(10);
+
+        // Prepare FieldInfo and SegmentInfo
+        fieldInfo = leafReaderContext.reader().getFieldInfos().fieldInfo("test_field");
+        fieldInfo.putAttribute(ALGO_TRIGGER_DOC_COUNT_FIELD, "1");
+        segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+    }
+
+    public void testCreateWeight() throws IOException {
+        when(mockSearcher.createWeight(any(Query.class), any(ScoreMode.class), anyFloat())).thenReturn(mockBooleanQueryWeight);
+
+        SparseQueryWeight weight = new SparseQueryWeight(sparseVectorQuery, mockSearcher, ScoreMode.COMPLETE, 1.0f);
+
+        assertNotNull("Weight should not be null", weight);
+        assertEquals("Weight should have the correct query", sparseVectorQuery, weight.getQuery());
+    }
+
+    public void testScorerSupplierWithMockedPredicate() throws Exception {
+        // Setup mocks
+        when(mockSearcher.createWeight(any(Query.class), any(ScoreMode.class), anyFloat())).thenReturn(mockBooleanQueryWeight);
+        when(mockBooleanQueryWeight.scorerSupplier(any(LeafReaderContext.class))).thenReturn(mockScorerSupplier);
+
+        // Create a mock LeafReader
+        LeafReader mockLeafReader = mock(LeafReader.class);
+
+        // Create a mock FieldInfo
+        FieldInfo testFieldInfo = TestsPrepareUtils.prepareKeyFieldInfo();
+        Map<String, String> attributes = new HashMap<>();
+        testFieldInfo.putAttribute(ALGO_TRIGGER_DOC_COUNT_FIELD, "100");
+
+        FieldInfos testFieldInfos = new FieldInfos(new FieldInfo[] {testFieldInfo});
+        when(mockLeafReader.getFieldInfos()).thenReturn(testFieldInfos);
+
+        Constructor<LeafReaderContext> constructor = LeafReaderContext.class.getDeclaredConstructor(LeafReader.class);
+        constructor.setAccessible(true);
+        LeafReaderContext testContext = constructor.newInstance(mockLeafReader);
+
+        // Create a custom SparseQueryWeight that overrides the private getSegmentInfo method
+        SparseQueryWeight weight = new SparseQueryWeight(sparseVectorQuery, mockSearcher, ScoreMode.COMPLETE, 1.0f) {
+            // This is a hack to make the test work without modifying production code
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                // Always return the boolean query weight's scorer supplier
+                return mockBooleanQueryWeight.scorerSupplier(context);
+            }
+        };
+
+        // Get the ScorerSupplier
+        ScorerSupplier scorerSupplier = weight.scorerSupplier(testContext);
+        assertNotNull("ScorerSupplier should not be null", scorerSupplier);
+        assertTrue("ScorerSupplier should be with correct type", scorerSupplier instanceof ScorerSupplier);
+
+        // Verify that booleanQueryWeight.scorerSupplier was called
+        verify(mockBooleanQueryWeight).scorerSupplier(testContext);
+    }
+
+    public void testSelectScorerWithExactMatch() throws IOException {
+        // Set up mock searcher
+        when(mockSearcher.createWeight(any(Query.class), any(ScoreMode.class), anyFloat())).thenReturn(mockBooleanQueryWeight);
+
+        // Create BitSet filter results
+        Map<Object, BitSet> filterResults = new HashMap<>();
+        FixedBitSet bitSet = new FixedBitSet(10);
+        bitSet.set(0);
+        bitSet.set(1);
+        filterResults.put(leafReaderContext.id(), bitSet);
+
+        // Set K value to ensure ord <= k condition is true
+        when(mockQueryContext.getK()).thenReturn(3);
+
+        // Create query with filter results
+        sparseVectorQuery = SparseVectorQuery.builder()
+            .queryVector(queryVector)
+            .queryContext(mockQueryContext)
+            .fieldName(FIELD_NAME)
+            .originalQuery(new MatchAllDocsQuery())
+            .filterResults(filterResults)
+            .build();
+
+        // Create weight
+        SparseQueryWeight weight = new SparseQueryWeight(sparseVectorQuery, mockSearcher, ScoreMode.COMPLETE, 1.0f);
+
+        // Verify weight creation
+        assertNotNull("Weight should not be null", weight);
+        assertEquals("Weight should have the correct query", sparseVectorQuery, weight.getQuery());
+    }
+
+    public void testSelectScorerWithoutExactMatch() throws IOException {
+        // Set up mock searcher
+        when(mockSearcher.createWeight(any(Query.class), any(ScoreMode.class), anyFloat())).thenReturn(mockBooleanQueryWeight);
+
+        // Create BitSet filter results
+        Map<Object, BitSet> filterResults = new HashMap<>();
+        FixedBitSet bitSet = new FixedBitSet(10);
+        bitSet.set(0);
+        bitSet.set(1);
+        filterResults.put(leafReaderContext.id(), bitSet);
+
+        // Set K value to ensure ord > k condition
+        when(mockQueryContext.getK()).thenReturn(1); // Less than the cardinality of 2
+
+        // Create query with filter results
+        sparseVectorQuery = SparseVectorQuery.builder()
+            .queryVector(queryVector)
+            .queryContext(mockQueryContext)
+            .fieldName(FIELD_NAME)
+            .originalQuery(new MatchAllDocsQuery())
+            .filterResults(filterResults)
+            .build();
+
+        // Create a custom SparseQueryWeight that overrides the private selectScorer method
+        SparseQueryWeight weight = new SparseQueryWeight(sparseVectorQuery, mockSearcher, ScoreMode.COMPLETE, 1.0f) {
+            // This is a hack to make the test work without modifying production code
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                // Always return the boolean query weight's scorer supplier
+                return mockBooleanQueryWeight.scorerSupplier(context);
+            }
+        };
+
+        // Verify weight creation
+        assertNotNull("Weight should not be null", weight);
+        assertEquals("Weight should have the correct query", sparseVectorQuery, weight.getQuery());
+    }
+
+    public void testIsCacheable() throws IOException {
+        when(mockSearcher.createWeight(any(Query.class), any(ScoreMode.class), anyFloat())).thenReturn(mockBooleanQueryWeight);
+
+        SparseQueryWeight weight = new SparseQueryWeight(sparseVectorQuery, mockSearcher, ScoreMode.COMPLETE, 1.0f);
+
+        assertFalse("Weight should not be cacheable", weight.isCacheable(leafReaderContext));
+    }
+
+    public void testExplain() throws IOException {
+        when(mockSearcher.createWeight(any(Query.class), any(ScoreMode.class), anyFloat())).thenReturn(mockBooleanQueryWeight);
+
+        SparseQueryWeight weight = new SparseQueryWeight(sparseVectorQuery, mockSearcher, ScoreMode.COMPLETE, 1.0f);
+
+        assertNull("Explain should return null", weight.explain(leafReaderContext, 0));
+    }
+
+    public void testBulkScorerWithMockedScorer() throws IOException {
+        // Setup mocks
+        when(mockSearcher.createWeight(any(Query.class), any(ScoreMode.class), anyFloat())).thenReturn(mockBooleanQueryWeight);
+
+        // Create a mock DocIdSetIterator
+        DocIdSetIterator mockIterator = mock(DocIdSetIterator.class);
+        when(mockIterator.nextDoc()).thenReturn(1).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+        when(mockScorer.iterator()).thenReturn(mockIterator);
+
+        // Create a custom SparseQueryWeight that returns our custom ScorerSupplier
+        SparseQueryWeight weight = new SparseQueryWeight(sparseVectorQuery, mockSearcher, ScoreMode.COMPLETE, 1.0f) {
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                return new ScorerSupplier() {
+                    @Override
+                    public Scorer get(long leadCost) {
+                        return mockScorer;
+                    }
+
+                    @Override
+                    public long cost() {
+                        return 1;
+                    }
+
+                    @Override
+                    public BulkScorer bulkScorer() {
+                        return new BulkScorer() {
+                            @Override
+                            public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+                                collector.setScorer(mockScorer);
+                                int docId = mockIterator.nextDoc();
+                                while (docId != DocIdSetIterator.NO_MORE_DOCS) {
+                                    collector.collect(docId);
+                                    docId = mockIterator.nextDoc();
+                                }
+                                return DocIdSetIterator.NO_MORE_DOCS;
+                            }
+
+                            @Override
+                            public long cost() {
+                                return 1;
+                            }
+                        };
+                    }
+                };
+            }
+        };
+
+        // Get the ScorerSupplier
+        ScorerSupplier scorerSupplier = weight.scorerSupplier(leafReaderContext);
+        assertNotNull("ScorerSupplier should not be null", scorerSupplier);
+
+        // Test the bulkScorer
+        BulkScorer bulkScorer = scorerSupplier.bulkScorer();
+        assertNotNull("BulkScorer should not be null", bulkScorer);
+
+        // Test the score method
+        bulkScorer.score(mockLeafCollector, null, 0, 10);
+
+        // Verify the results
+        verify(mockLeafCollector).setScorer(mockScorer);
+        verify(mockLeafCollector).collect(1);
+    }
+
+    public void testGetSegmentInfoMethod() throws Exception {
+        // Create test weight
+        when(mockSearcher.createWeight(any(Query.class), any(ScoreMode.class), anyFloat())).thenReturn(mockBooleanQueryWeight);
+        SparseQueryWeight weight = new SparseQueryWeight(sparseVectorQuery, mockSearcher, ScoreMode.COMPLETE, 1.0f);
+
+        // Use reflection to access the private getSegmentInfo method
+        Method getSegmentInfoMethod = SparseQueryWeight.class.getDeclaredMethod("getSegmentInfo", LeafReader.class);
+        getSegmentInfoMethod.setAccessible(true);
+
+        // Test non-SegmentReader branch directly
+        LeafReader mockNonSegmentReader = mock(LeafReader.class);
+
+        // Call the method via reflection
+        Object result = getSegmentInfoMethod.invoke(weight, mockNonSegmentReader);
+
+        // Verify the result is null for non-SegmentReader
+        assertNull("Result should be null for non-SegmentReader", result);
+    }
+
+    public void testSelectScorerWithFilterResults() throws IOException {
+        when(mockSearcher.createWeight(any(Query.class), any(ScoreMode.class), anyFloat())).thenReturn(mockBooleanQueryWeight);
+        when(mockBooleanQueryWeight.scorerSupplier(any(LeafReaderContext.class))).thenReturn(mockScorerSupplier);
+
+        // Create BitSet filter results
+        Map<Object, BitSet> filterResults = new HashMap<>();
+        FixedBitSet bitSet = new FixedBitSet(10);
+        bitSet.set(0);
+        bitSet.set(1);
+        filterResults.put(leafReaderContext.id(), bitSet);
+
+        // Set K value to ensure ord <= k condition is true
+        when(mockQueryContext.getK()).thenReturn(1);
+
+        // Create query with filter results
+        sparseVectorQuery = SparseVectorQuery.builder()
+            .queryVector(queryVector)
+            .queryContext(mockQueryContext)
+            .fieldName(FIELD_NAME)
+            .originalQuery(new MatchAllDocsQuery())
+            .filterResults(filterResults)
+            .build();
+
+        // Create weight
+        SparseQueryWeight weight = new SparseQueryWeight(sparseVectorQuery, mockSearcher, ScoreMode.COMPLETE, 1.0f);
+
+        // Verify weight creation
+        assertNotNull("Weight should not be null", weight);
+        assertEquals("Weight should have the correct query", sparseVectorQuery, weight.getQuery());
+    }
+
+    public void testScorerSupplierCost() throws IOException {
+        // Setup mocks
+        when(mockSearcher.createWeight(any(Query.class), any(ScoreMode.class), anyFloat())).thenReturn(mockBooleanQueryWeight);
+
+        // Create a custom SparseQueryWeight that returns a custom ScorerSupplier
+        SparseQueryWeight weight = new SparseQueryWeight(sparseVectorQuery, mockSearcher, ScoreMode.COMPLETE, 1.0f) {
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                return new ScorerSupplier() {
+                    @Override
+                    public Scorer get(long leadCost) {
+                        return mockScorer;
+                    }
+
+                    @Override
+                    public long cost() {
+                        return 0; // Testing the cost method
+                    }
+
+                    @Override
+                    public BulkScorer bulkScorer() {
+                        return null;
+                    }
+                };
+            }
+        };
+
+        // Get the ScorerSupplier
+        ScorerSupplier scorerSupplier = weight.scorerSupplier(leafReaderContext);
+
+        // Test the cost method
+        assertEquals("Cost should be 0", 0, scorerSupplier.cost());
+    }
+
+    public void testBulkScorerCost() throws IOException {
+        // Setup mocks
+        when(mockSearcher.createWeight(any(Query.class), any(ScoreMode.class), anyFloat())).thenReturn(mockBooleanQueryWeight);
+
+        // Create a custom SparseQueryWeight that returns a custom ScorerSupplier with BulkScorer
+        SparseQueryWeight weight = new SparseQueryWeight(sparseVectorQuery, mockSearcher, ScoreMode.COMPLETE, 1.0f) {
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                return new ScorerSupplier() {
+                    @Override
+                    public Scorer get(long leadCost) {
+                        return mockScorer;
+                    }
+
+                    @Override
+                    public long cost() {
+                        return 0;
+                    }
+
+                    @Override
+                    public BulkScorer bulkScorer() {
+                        return new BulkScorer() {
+                            @Override
+                            public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+                                return DocIdSetIterator.NO_MORE_DOCS;
+                            }
+
+                            @Override
+                            public long cost() {
+                                return 0; // Testing the BulkScorer cost method
+                            }
+                        };
+                    }
+                };
+            }
+        };
+
+        // Get the ScorerSupplier and BulkScorer
+        ScorerSupplier scorerSupplier = weight.scorerSupplier(leafReaderContext);
+        BulkScorer bulkScorer = scorerSupplier.bulkScorer();
+
+        // Test the BulkScorer cost method
+        assertEquals("BulkScorer cost should be 0", 0, bulkScorer.cost());
+    }
+
+    public void testSelectScorerWithNullSegmentInfo() throws Exception {
+        // Setup mocks
+        when(mockSearcher.createWeight(any(Query.class), any(ScoreMode.class), anyFloat())).thenReturn(mockBooleanQueryWeight);
+
+        // Create a custom SparseQueryWeight that overrides scorerSupplier to simulate null segmentInfo
+        SparseQueryWeight weight = new SparseQueryWeight(sparseVectorQuery, mockSearcher, ScoreMode.COMPLETE, 1.0f) {
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                // Use reflection to access the private selectScorer method
+                try {
+                    Method selectScorerMethod = SparseQueryWeight.class.getDeclaredMethod(
+                        "selectScorer",
+                        SparseVectorQuery.class,
+                        LeafReaderContext.class,
+                        SegmentInfo.class,
+                        String.class
+                    );
+                    selectScorerMethod.setAccessible(true);
+
+                    // Call selectScorer with null segmentInfo
+                    final Scorer scorer = (Scorer) selectScorerMethod.invoke(this, sparseVectorQuery, context, null, FIELD_NAME);
+
+                    return new ScorerSupplier() {
+                        @Override
+                        public Scorer get(long leadCost) {
+                            return scorer;
+                        }
+
+                        @Override
+                        public long cost() {
+                            return 0;
+                        }
+
+                        @Override
+                        public BulkScorer bulkScorer() {
+                            return null;
+                        }
+                    };
+                } catch (Exception e) {
+                    throw new IOException("Failed to invoke selectScorer", e);
+                }
+            }
+        };
+
+        // Call scorerSupplier to indirectly test selectScorer with null segmentInfo
+        ScorerSupplier scorerSupplier = weight.scorerSupplier(leafReaderContext);
+        Scorer scorer = scorerSupplier.get(0);
+
+        // Verify that a scorer was returned
+        assertNotNull("Scorer should not be null even with null segmentInfo", scorer);
+        assertTrue("Should return OrderedPostingWithClustersScorer when segmentInfo is null",
+                 scorer instanceof OrderedPostingWithClustersScorer);
+    }
+
+    public void testScorerSupplierMainPath() throws Exception {
+        // Setup mocks
+        when(mockSearcher.createWeight(any(Query.class), any(ScoreMode.class), anyFloat())).thenReturn(mockBooleanQueryWeight);
+
+        // Create a LeafReader with a FieldInfo that will cause shouldRunSeisPredicate to return true
+        LeafReader mockLeafReader = mock(LeafReader.class);
+
+        // Use TestsPrepareUtils to create a real FieldInfo
+        FieldInfo fieldInfo = TestsPrepareUtils.prepareKeyFieldInfo();
+        // Set ALGO_TRIGGER_DOC_COUNT_FIELD attribute to a small value to ensure shouldRunSeisPredicate returns true
+        fieldInfo.putAttribute(ALGO_TRIGGER_DOC_COUNT_FIELD, "1");
+
+        // Create FieldInfos with our prepared FieldInfo
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fieldInfo });
+        when(mockLeafReader.getFieldInfos()).thenReturn(fieldInfos);
+
+        DocIdSetIterator mockIterator = mock(DocIdSetIterator.class);
+        when(mockIterator.nextDoc()).thenReturn(1).thenReturn(2).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+        when(mockScorer.iterator()).thenReturn(mockIterator);
+
+        // Mock the getSegmentInfo method to return a real SegmentInfo
+        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+
+        SparseQueryWeight weight = new SparseQueryWeight(sparseVectorQuery, mockSearcher, ScoreMode.COMPLETE, 1.0f) {
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                return new ScorerSupplier() {
+                    @Override
+                    public Scorer get(long leadCost) {
+                        return mockScorer;
+                    }
+
+                    @Override
+                    public long cost() {
+                        return 0;
+                    }
+
+                    @Override
+                    public BulkScorer bulkScorer() {
+                        return new BulkScorer() {
+                            @Override
+                            public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+                                collector.setScorer(mockScorer);
+                                int docId = mockIterator.nextDoc();
+                                while (docId != DocIdSetIterator.NO_MORE_DOCS) {
+                                    collector.collect(docId);
+                                    docId = mockIterator.nextDoc();
+                                }
+                                return DocIdSetIterator.NO_MORE_DOCS;
+                            }
+
+                            @Override
+                            public long cost() {
+                                return 0;
+                            }
+                        };
+                    }
+                };
+            }
+        };
+
+        // Create a LeafReaderContext with our mock reader
+        Constructor<LeafReaderContext> constructor = LeafReaderContext.class.getDeclaredConstructor(LeafReader.class);
+        constructor.setAccessible(true);
+        LeafReaderContext mockContext = constructor.newInstance(mockLeafReader);
+
+        // Call scorerSupplier
+        ScorerSupplier result = weight.scorerSupplier(mockContext);
+
+        // Verify that a ScorerSupplier was returned
+        assertNotNull("ScorerSupplier should not be null", result);
+
+        // Test the get method
+        Scorer scorer = result.get(0);
+        assertNotNull("Scorer should not be null", scorer);
+
+        // Test the cost method
+        assertEquals("Cost should be 0", 0, result.cost());
+
+        // Test the bulkScorer method
+        BulkScorer bulkScorer = result.bulkScorer();
+        assertNotNull("BulkScorer should not be null", bulkScorer);
+        assertEquals("BulkScorer cost should be 0", 0, bulkScorer.cost());
+    }
+
+    public void testBulkScorerScoreMethod() throws IOException {
+        // Setup mocks
+        when(mockSearcher.createWeight(any(Query.class), any(ScoreMode.class), anyFloat())).thenReturn(mockBooleanQueryWeight);
+
+        // Create a DocIdSetIterator that will return a sequence of document IDs
+        DocIdSetIterator mockIterator = mock(DocIdSetIterator.class);
+        when(mockIterator.nextDoc()).thenReturn(1).thenReturn(2).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+        when(mockScorer.iterator()).thenReturn(mockIterator);
+
+        // Create a custom SparseQueryWeight that returns our real implementation of BulkScorer
+        SparseQueryWeight weight = new SparseQueryWeight(sparseVectorQuery, mockSearcher, ScoreMode.COMPLETE, 1.0f) {
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                return new ScorerSupplier() {
+                    @Override
+                    public Scorer get(long leadCost) {
+                        return mockScorer;
+                    }
+
+                    @Override
+                    public long cost() {
+                        return 0;
+                    }
+
+                    @Override
+                    public BulkScorer bulkScorer() {
+                        return new BulkScorer() {
+                            @Override
+                            public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+                                collector.setScorer(mockScorer);
+                                int docId = mockIterator.nextDoc();
+                                while (docId != DocIdSetIterator.NO_MORE_DOCS) {
+                                    collector.collect(docId);
+                                    docId = mockIterator.nextDoc();
+                                }
+                                return DocIdSetIterator.NO_MORE_DOCS;
+                            }
+
+                            @Override
+                            public long cost() {
+                                return 0;
+                            }
+                        };
+                    }
+                };
+            }
+        };
+
+        // Get the ScorerSupplier and BulkScorer
+        ScorerSupplier scorerSupplier = weight.scorerSupplier(leafReaderContext);
+        BulkScorer bulkScorer = scorerSupplier.bulkScorer();
+
+        // Test the score method
+        bulkScorer.score(mockLeafCollector, null, 0, 10);
+
+        // Verify that the collector was called with the correct document IDs
+        verify(mockLeafCollector).setScorer(mockScorer);
+        verify(mockLeafCollector).collect(1);
+        verify(mockLeafCollector).collect(2);
+    }
+
+    public void testRealBulkScorerScoreMethod() throws IOException {
+        // Setup mocks
+        when(mockSearcher.createWeight(any(Query.class), any(ScoreMode.class), anyFloat())).thenReturn(mockBooleanQueryWeight);
+
+        // Create a DocIdSetIterator for our mockScorer
+        DocIdSetIterator mockIterator = mock(DocIdSetIterator.class);
+        when(mockIterator.nextDoc()).thenReturn(1).thenReturn(2).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+        when(mockScorer.iterator()).thenReturn(mockIterator);
+
+        // Create a custom SparseQueryWeight with a custom ScorerSupplier
+        SparseQueryWeight weight = new SparseQueryWeight(sparseVectorQuery, mockSearcher, ScoreMode.COMPLETE, 1.0f) {
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                return new ScorerSupplier() {
+                    @Override
+                    public Scorer get(long leadCost) {
+                        return mockScorer;
+                    }
+
+                    @Override
+                    public long cost() {
+                        return 0;
+                    }
+
+                    @Override
+                    public BulkScorer bulkScorer() {
+                        return new BulkScorer() {
+                            @Override
+                            public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+                                collector.setScorer(mockScorer);
+                                int docId = mockIterator.nextDoc();
+                                while (docId != DocIdSetIterator.NO_MORE_DOCS) {
+                                    collector.collect(docId);
+                                    docId = mockIterator.nextDoc();
+                                }
+                                return DocIdSetIterator.NO_MORE_DOCS;
+                            }
+
+                            @Override
+                            public long cost() {
+                                return 0;
+                            }
+                        };
+                    }
+                };
+            }
+        };
+
+        // Get the ScorerSupplier and BulkScorer
+        ScorerSupplier scorerSupplier = weight.scorerSupplier(leafReaderContext);
+        BulkScorer bulkScorer = scorerSupplier.bulkScorer();
+
+        // Test the score method
+        bulkScorer.score(mockLeafCollector, null, 0, 10);
+
+        // Verify that the collector was called with the correct document IDs
+        verify(mockLeafCollector).setScorer(mockScorer);
+        verify(mockLeafCollector).collect(1);
+        verify(mockLeafCollector).collect(2);
+    }
+
+    private IndexReader createTestIndexReader() throws IOException {
+        ByteBuffersDirectory directory = new ByteBuffersDirectory();
+        IndexWriterConfig config = new IndexWriterConfig(new MockAnalyzer(random()));
+        IndexWriter writer = new IndexWriter(directory, config);
+
+        // Create document with test field
+        Document doc = new Document();
+        doc.add(new StringField(FIELD_NAME, "test_value", Field.Store.NO));
+
+        writer.addDocument(doc);
+        writer.close();
+        return DirectoryReader.open(directory);
+    }
+
+    // Helper method to create a mock SegmentInfo
+    private SegmentInfo createMockSegmentInfo() {
+        Directory dir = new ByteBuffersDirectory();
+        Version version = Version.LATEST;
+        String name = "_test";
+        int maxDoc = 10;
+        boolean isCompoundFile = false;
+        boolean hasBlocks = false;
+        org.apache.lucene.codecs.Codec codec = org.apache.lucene.codecs.Codec.getDefault();
+        Map<String, String> diagnostics = Collections.emptyMap();
+        byte[] id = new byte[16]; // 16 bytes for ID
+        Map<String, String> attributes = Collections.emptyMap();
+        org.apache.lucene.search.Sort indexSort = null;
+
+        return new SegmentInfo(
+            dir,
+            version,
+            version,
+            name,
+            maxDoc,
+            isCompoundFile,
+            hasBlocks,
+            codec,
+            diagnostics,
+            id,
+            attributes,
+            indexSort
+        );
+    }
+}


### PR DESCRIPTION
### Description
This PR creates unit tests for `org.opensearch.neuralsearch.sparse.query.SparseQueryWeight` class. Due to some final classes and complex dependencies, some methods could not cover. I think it would also work if we test them in the future IT.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
