### PR TITLE
Fix BatchClusteringTaskTest: a non-null segmentInfo

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/BatchClusteringTaskTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/BatchClusteringTaskTests.java
@@ -30,7 +30,7 @@ public class BatchClusteringTaskTests extends AbstractSparseTestBase {
         MockitoAnnotations.openMocks(this);
 
         terms = Arrays.asList(new BytesRef("term1"), new BytesRef("term2"));
-        key = new InMemoryKey.IndexKey(null, "test_field");
+        key = new InMemoryKey.IndexKey(TestsPrepareUtils.prepareSegmentInfo(), "test_field");
     }
 
     public void testConstructorDeepCopiesTerms() throws Exception {


### PR DESCRIPTION
### Description
This PR fixes the null `segmentInfo` issue in the `BatchClusteringTaskTest`. Now, all unit tests can work correctly.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
