### PR TITLE
[Unit Tests] SparseDocValuesProducer

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesProducerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesProducerTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SparseDocValuesProducerTests extends AbstractSparseTestBase {
+
+    private DocValuesProducer mockDelegate;
+    private SegmentReadState segmentReadState;
+    private SparseDocValuesProducer producer;
+    private FieldInfo fieldInfo;
+    private SegmentInfo segmentInfo;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mockDelegate = mock(DocValuesProducer.class);
+
+        // Mock components for SegmentReadState
+        Directory mockDir = mock(Directory.class);
+        segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+        FieldInfos mockFieldInfos = mock(FieldInfos.class);
+        IOContext ioContext = IOContext.DEFAULT;
+
+        // Create a real SegmentReadState with mocked components
+        segmentReadState = new SegmentReadState(
+            mockDir,         // directory
+            segmentInfo,     // segmentInfo
+            mockFieldInfos,  // fieldInfos
+            ioContext      // context
+        );
+
+        producer = new SparseDocValuesProducer(segmentReadState, mockDelegate);
+        fieldInfo = TestsPrepareUtils.prepareKeyFieldInfo();
+    }
+
+    public void testGetNumeric() throws IOException {
+        // Setup
+        NumericDocValues mockNumeric = mock(NumericDocValues.class);
+        when(mockDelegate.getNumeric(fieldInfo)).thenReturn(mockNumeric);
+
+        // Execute
+        NumericDocValues result = producer.getNumeric(fieldInfo);
+
+        // Verify
+        assertEquals(mockNumeric, result);
+        verify(mockDelegate).getNumeric(fieldInfo);
+    }
+
+    public void testGetBinary() throws IOException {
+        // Setup
+        BinaryDocValues mockBinary = mock(BinaryDocValues.class);
+        when(mockDelegate.getBinary(fieldInfo)).thenReturn(mockBinary);
+
+        // Execute
+        BinaryDocValues result = producer.getBinary(fieldInfo);
+
+        // Verify
+        assertTrue(result instanceof SparseBinaryDocValuesPassThrough);
+        SparseBinaryDocValuesPassThrough passThrough = (SparseBinaryDocValuesPassThrough) result;
+        assertEquals(segmentReadState.segmentInfo, passThrough.getSegmentInfo());
+        verify(mockDelegate).getBinary(fieldInfo);
+    }
+
+    public void testGetSorted() throws IOException {
+        // Setup
+        SortedDocValues mockSorted = mock(SortedDocValues.class);
+        when(mockDelegate.getSorted(fieldInfo)).thenReturn(mockSorted);
+
+        // Execute
+        SortedDocValues result = producer.getSorted(fieldInfo);
+
+        // Verify
+        assertEquals(mockSorted, result);
+        verify(mockDelegate).getSorted(fieldInfo);
+    }
+
+    public void testGetSortedNumeric() throws IOException {
+        // Setup
+        SortedNumericDocValues mockSortedNumeric = mock(SortedNumericDocValues.class);
+        when(mockDelegate.getSortedNumeric(fieldInfo)).thenReturn(mockSortedNumeric);
+
+        // Execute
+        SortedNumericDocValues result = producer.getSortedNumeric(fieldInfo);
+
+        // Verify
+        assertEquals(mockSortedNumeric, result);
+        verify(mockDelegate).getSortedNumeric(fieldInfo);
+    }
+
+    public void testGetSortedSet() throws IOException {
+        // Setup
+        SortedSetDocValues mockSortedSet = mock(SortedSetDocValues.class);
+        when(mockDelegate.getSortedSet(fieldInfo)).thenReturn(mockSortedSet);
+
+        // Execute
+        SortedSetDocValues result = producer.getSortedSet(fieldInfo);
+
+        // Verify
+        assertEquals(mockSortedSet, result);
+        verify(mockDelegate).getSortedSet(fieldInfo);
+    }
+
+    public void testGetSkipper() throws IOException {
+        // Setup
+        DocValuesSkipper mockSkipper = mock(DocValuesSkipper.class);
+        when(mockDelegate.getSkipper(fieldInfo)).thenReturn(mockSkipper);
+
+        // Execute
+        DocValuesSkipper result = producer.getSkipper(fieldInfo);
+
+        // Verify
+        assertEquals(mockSkipper, result);
+        verify(mockDelegate).getSkipper(fieldInfo);
+    }
+
+    public void testCheckIntegrity() throws IOException {
+        // Execute
+        producer.checkIntegrity();
+
+        // Verify
+        verify(mockDelegate).checkIntegrity();
+    }
+
+    public void testClose() throws IOException {
+        // Execute
+        producer.close();
+
+        // Verify
+        verify(mockDelegate).close();
+    }
+
+    public void testGetState() {
+        // Execute
+        SegmentReadState result = producer.getState();
+
+        // Verify
+        assertEquals(segmentReadState, result);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesProducerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesProducerTests.java
@@ -50,7 +50,7 @@ public class SparseDocValuesProducerTests extends AbstractSparseTestBase {
             mockDir,         // directory
             segmentInfo,     // segmentInfo
             mockFieldInfos,  // fieldInfos
-            ioContext      // context
+            ioContext        // context
         );
 
         producer = new SparseDocValuesProducer(segmentReadState, mockDelegate);


### PR DESCRIPTION
### Description
This PR creates unit tests for `org.opensearch.neuralsearch.sparse.codec.SparseDocValuesProducer` class. It achieves 100% coverage.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
