### PR TITLE
Add MergeStateFacade for easy testing

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
@@ -17,6 +17,7 @@ import org.apache.lucene.util.BytesRef;
 import org.opensearch.neuralsearch.sparse.SparseTokensField;
 import org.opensearch.neuralsearch.sparse.common.InMemoryKey;
 import org.opensearch.neuralsearch.sparse.common.MergeHelper;
+import org.opensearch.neuralsearch.sparse.common.MergeStateFacade;
 import org.opensearch.neuralsearch.sparse.common.PredicateUtils;
 import org.opensearch.neuralsearch.sparse.common.SparseVector;
 import org.opensearch.neuralsearch.sparse.common.SparseVectorForwardIndex;
@@ -83,7 +84,7 @@ public class SparseDocValuesConsumer extends DocValuesConsumer {
         }
         if (isMerge) {
             if (valuesProducer instanceof SparseDocValuesReader reader) {
-                MergeHelper.clearInMemoryData(reader.getMergeState(), field, SparseVectorForwardIndex::removeIndex);
+                MergeHelper.clearInMemoryData(new MergeStateFacade(reader.getMergeState()), field, SparseVectorForwardIndex::removeIndex);
             }
         }
     }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumer.java
@@ -21,6 +21,7 @@ import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.neuralsearch.sparse.SparseTokensField;
 import org.opensearch.neuralsearch.sparse.common.MergeHelper;
+import org.opensearch.neuralsearch.sparse.common.MergeStateFacade;
 import org.opensearch.neuralsearch.sparse.common.PredicateUtils;
 
 import java.io.IOException;
@@ -166,7 +167,7 @@ public class SparsePostingsConsumer extends FieldsConsumer {
         try {
             SparsePostingsReader sparsePostingsReader = new SparsePostingsReader(mergeState);
             sparsePostingsReader.merge(this.sparseTermsLuceneWriter, this.clusteredPostingTermsWriter);
-            MergeHelper.clearInMemoryData(mergeState, null, InMemoryClusteredPosting::clearIndex);
+            MergeHelper.clearInMemoryData(new MergeStateFacade(mergeState), null, InMemoryClusteredPosting::clearIndex);
         } catch (Exception e) {
             log.error("Merge sparse postings error", e);
         }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/common/MergeHelper.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/common/MergeHelper.java
@@ -7,7 +7,6 @@ package org.opensearch.neuralsearch.sparse.common;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.MergeState;
 import org.opensearch.neuralsearch.sparse.SparseTokensField;
 import org.opensearch.neuralsearch.sparse.codec.SparseBinaryDocValuesPassThrough;
 
@@ -15,10 +14,10 @@ import java.io.IOException;
 import java.util.function.Consumer;
 
 public class MergeHelper {
-    public static void clearInMemoryData(MergeState mergeState, FieldInfo fieldInfo, Consumer<InMemoryKey.IndexKey> consumer)
+    public static void clearInMemoryData(MergeStateFacade mergeState, FieldInfo fieldInfo, Consumer<InMemoryKey.IndexKey> consumer)
         throws IOException {
-        for (DocValuesProducer producer : mergeState.docValuesProducers) {
-            for (FieldInfo field : mergeState.mergeFieldInfos) {
+        for (DocValuesProducer producer : mergeState.getDocValuesProducers()) {
+            for (FieldInfo field : mergeState.getMergeFieldInfos()) {
                 if (!SparseTokensField.isSparseField(field) || (fieldInfo != null && field != fieldInfo)) {
                     continue;
                 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/common/MergeStateFacade.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/common/MergeStateFacade.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.common;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.util.Bits;
+
+/**
+ * Since {@link MergeState}'s fields are not capsulated and doesn't have accessors, it's not easy to
+ * mock its functionalities in UTs, thus, we wrap it in this class to provide better testability.
+ */
+@AllArgsConstructor
+public class MergeStateFacade {
+    @NonNull
+    private final MergeState mergeState;
+
+    public DocValuesProducer[] getDocValuesProducers() {
+        return mergeState.docValuesProducers;
+    }
+
+    public FieldInfos getMergeFieldInfos() {
+        return mergeState.mergeFieldInfos;
+    }
+
+    public int[] getMaxDocs() {
+        return mergeState.maxDocs;
+    }
+
+    public MergeState.DocMap[] getDocMaps() {
+        return mergeState.docMaps;
+    }
+
+    public Bits[] getLiveDocs() {
+        return mergeState.liveDocs;
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/common/MergeHelperTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/common/MergeHelperTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.common;
+
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.junit.Before;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MergeHelperTests extends AbstractSparseTestBase {
+
+    private MergeStateFacade mergeStateFacade;
+    private DocValuesProducer docValuesProducer1;
+    private DocValuesProducer docValuesProducer2;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        // final String inlineMockMaker = "org.mockito.internal.creation.bytebuddy.InlineByteBuddyMockMaker";
+        // MockSettings mockSettingsWithInlineMockMaker = new MockSettingsImpl().mockMaker(inlineMockMaker);
+
+        mergeStateFacade = mock(MergeStateFacade.class);
+        DocValuesProducer docValuesProducer1 = mock(DocValuesProducer.class);
+        DocValuesProducer docValuesProducer2 = mock(DocValuesProducer.class);
+
+        FieldInfo fieldInfo1 = mock(FieldInfo.class);
+        FieldInfo fieldInfo2 = mock(FieldInfo.class);
+        List<FieldInfo> fields = Arrays.asList(fieldInfo1, fieldInfo2);
+
+        FieldInfos fieldInfos = mock(FieldInfos.class);
+        when(fieldInfos.iterator()).thenReturn(fields.iterator());
+        when(mergeStateFacade.getMergeFieldInfos()).thenReturn(fieldInfos);
+
+    }
+
+    public void testClear() throws IOException {
+        when(mergeStateFacade.getDocValuesProducers()).thenReturn(new DocValuesProducer[]{docValuesProducer1, docValuesProducer2});
+        MergeHelper.clearInMemoryData(mergeStateFacade, null, (t) -> {
+
+        });
+        assertTrue(true);
+    }
+
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/common/MergeStateFacadeTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/common/MergeStateFacadeTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.common;
+
+import org.apache.lucene.index.MergeState;
+import org.junit.Before;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
+
+/**
+ * Unit tests for {@link MergeStateFacade}
+ */
+public class MergeStateFacadeTests extends AbstractSparseTestBase {
+
+    private MergeState mergeState;
+    private MergeStateFacade mergeStateFacade;
+
+    /**
+     * Setup method to initialize mocks before each test
+     */
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        // Initialize mocks
+        mergeState = TestsPrepareUtils.prepareMergeState(false);
+        // Create the facade with the mock
+        mergeStateFacade = new MergeStateFacade(mergeState);
+    }
+
+    /**
+     * Test that getDocValuesProducers returns the correct DocValuesProducer array
+     */
+    public void testGetDocValuesProducers() {
+        assertSame(mergeState.docValuesProducers, mergeStateFacade.getDocValuesProducers());
+    }
+
+    /**
+     * Test that getMergeFieldInfos returns the correct FieldInfos
+     */
+    public void testGetMergeFieldInfos() {
+        assertSame(mergeState.mergeFieldInfos, mergeStateFacade.getMergeFieldInfos());
+    }
+
+    /**
+     * Test that getMaxDocs returns the correct maxDocs array
+     */
+    public void testGetMaxDocs() {
+        assertSame(mergeState.maxDocs, mergeStateFacade.getMaxDocs());
+    }
+
+    /**
+     * Test that getDocMaps returns the correct DocMap array
+     */
+    public void testGetDocMaps() {
+        assertSame(mergeState.docMaps, mergeStateFacade.getDocMaps());
+    }
+
+    /**
+     * Test that getLiveDocs returns the correct Bits array
+     */
+    public void testGetLiveDocs() {
+        assertSame(mergeState.liveDocs, mergeStateFacade.getLiveDocs());
+    }
+
+    /**
+     * Test constructor with null MergeState
+     * Should throw NullPointerException
+     */
+    public void testConstructorWithNullMergeState() {
+        assertThrows(NullPointerException.class, () -> new MergeStateFacade(null));
+    }
+}


### PR DESCRIPTION
MergeState doesn't have capsulation of its fields and it doesn't offer accessor for those fields which make writting unit tests difficult, writing a facade class on top of it to make up for the functionalities and also hide unnecessary fields from usage.