### PR TITLE
[Unit Tests] SparseDocValuesFormat

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesFormatTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesFormatTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+public class SparseDocValuesFormatTests extends AbstractSparseTestBase {
+
+    private DocValuesFormat mockDelegate;
+    private SparseDocValuesFormat sparseDocValuesFormat;
+    private SegmentWriteState mockWriteState;
+    private SegmentReadState mockReadState;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mockDelegate = mock(DocValuesFormat.class);
+        when(mockDelegate.getName()).thenReturn("TestFormat");
+
+        sparseDocValuesFormat = new SparseDocValuesFormat(mockDelegate);
+        mockWriteState = mock(SegmentWriteState.class);
+        mockReadState = mock(SegmentReadState.class);
+    }
+
+    public void testConstructor() {
+        // Verify that the format name is inherited from delegate
+        assertEquals("TestFormat", sparseDocValuesFormat.getName());
+    }
+
+    public void testFieldsConsumer() throws IOException {
+        // Setup
+        DocValuesConsumer mockDelegateConsumer = mock(DocValuesConsumer.class);
+        when(mockDelegate.fieldsConsumer(mockWriteState)).thenReturn(mockDelegateConsumer);
+
+        // Execute
+        DocValuesConsumer result = sparseDocValuesFormat.fieldsConsumer(mockWriteState);
+
+        // Verify
+        assertNotNull(result);
+        assertTrue(result instanceof SparseDocValuesConsumer);
+        verify(mockDelegate).fieldsConsumer(mockWriteState);
+    }
+
+    public void testFieldsProducer() throws IOException {
+        // Setup
+        DocValuesProducer mockDelegateProducer = mock(DocValuesProducer.class);
+        when(mockDelegate.fieldsProducer(mockReadState)).thenReturn(mockDelegateProducer);
+
+        // Execute
+        DocValuesProducer result = sparseDocValuesFormat.fieldsProducer(mockReadState);
+
+        // Verify
+        assertNotNull(result);
+        assertTrue(result instanceof SparseDocValuesProducer);
+        verify(mockDelegate).fieldsProducer(mockReadState);
+    }
+
+    public void testFieldsConsumerIOException() throws IOException {
+        // Setup
+        IOException expectedException = new IOException("Test exception");
+        when(mockDelegate.fieldsConsumer(mockWriteState)).thenThrow(expectedException);
+
+        // Execute & Verify
+        IOException exception = expectThrows(IOException.class, () -> { sparseDocValuesFormat.fieldsConsumer(mockWriteState); });
+        assertEquals("Test exception", exception.getMessage());
+    }
+
+    public void testFieldsProducerIOException() throws IOException {
+        // Setup
+        IOException expectedException = new IOException("Test exception");
+        when(mockDelegate.fieldsProducer(mockReadState)).thenThrow(expectedException);
+
+        // Execute & Verify
+        IOException exception = expectThrows(IOException.class, () -> { sparseDocValuesFormat.fieldsProducer(mockReadState); });
+        assertEquals("Test exception", exception.getMessage());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesFormatTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesFormatTests.java
@@ -30,12 +30,13 @@ public class SparseDocValuesFormatTests extends AbstractSparseTestBase {
         mockDelegate = mock(DocValuesFormat.class);
         when(mockDelegate.getName()).thenReturn("TestFormat");
 
-        sparseDocValuesFormat = new SparseDocValuesFormat(mockDelegate);
+        this.sparseDocValuesFormat = new SparseDocValuesFormat(mockDelegate);
         mockWriteState = mock(SegmentWriteState.class);
         mockReadState = mock(SegmentReadState.class);
     }
 
     public void testConstructor() {
+        SparseDocValuesFormat sparseDocValuesFormat = new SparseDocValuesFormat(mockDelegate);
         // Verify that the format name is inherited from delegate
         assertEquals("TestFormat", sparseDocValuesFormat.getName());
     }


### PR DESCRIPTION
### Description
This PR creates unit tests for `org.opensearch.neuralsearch.sparse.codec.SparseDocValuesFormat` class. It achieves 100% coverage.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
