### PR TITLE
[Unit Tests] SparsePostingsFormat

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/sparse/TestsPrepareUtils.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/TestsPrepareUtils.java
@@ -112,7 +112,7 @@ public class TestsPrepareUtils {
             Version.LATEST,                // version
             Version.LATEST,                // minVersion
             "_test_segment",               // name
-            maxDoc,                            // maxDoc
+            maxDoc,                        // maxDoc
             false,                         // isCompoundFile
             false,                         // hasBlocks
             Codec.getDefault(),            // codec

--- a/src/test/java/org/opensearch/neuralsearch/sparse/TestsPrepareUtils.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/TestsPrepareUtils.java
@@ -8,8 +8,10 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.index.BinaryDocValues;
+
 import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexOptions;
@@ -26,6 +28,7 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.IndexableFieldType;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.Version;
@@ -84,6 +87,32 @@ public class TestsPrepareUtils {
             Version.LATEST,                // minVersion
             "_test_segment",               // name
             10,                            // maxDoc
+            false,                         // isCompoundFile
+            false,                         // hasBlocks
+            Codec.getDefault(),            // codec
+            Collections.emptyMap(),        // diagnostics
+            id,                            // id
+            Collections.emptyMap(),        // attributes
+            null                           // indexSort
+        );
+        return segmentInfo;
+    }
+
+    public static SegmentInfo prepareSegmentInfo(int maxDoc) {
+        MergeState.DocMap[] docMaps = new MergeState.DocMap[1];
+        docMaps[0] = docID -> docID;
+        Directory dir = new ByteBuffersDirectory();
+        byte[] id = new byte[16];
+        for (int i = 0; i < id.length; i++) {
+            id[i] = (byte) i;
+        }
+
+        SegmentInfo segmentInfo = new SegmentInfo(
+            dir,                           // directory
+            Version.LATEST,                // version
+            Version.LATEST,                // minVersion
+            "_test_segment",               // name
+            maxDoc,                            // maxDoc
             false,                         // isCompoundFile
             false,                         // hasBlocks
             Codec.getDefault(),            // codec
@@ -365,5 +394,22 @@ public class TestsPrepareUtils {
 
     public static ContentPath prepareContentPath() {
         return new ContentPath();
+    }
+
+    public static SegmentWriteState prepareSegmentWriteState() {
+        Directory directory = new ByteBuffersDirectory();
+        SegmentInfo segmentInfo = prepareSegmentInfo();
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { prepareKeyFieldInfo() });
+        IOContext ioContext = IOContext.DEFAULT;
+
+        return new SegmentWriteState(InfoStream.getDefault(), directory, segmentInfo, fieldInfos, null, ioContext);
+    }
+
+    public static SegmentWriteState prepareSegmentWriteState(SegmentInfo segmentInfo) {
+        Directory directory = new ByteBuffersDirectory();
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { prepareKeyFieldInfo() });
+        IOContext ioContext = IOContext.DEFAULT;
+
+        return new SegmentWriteState(InfoStream.getDefault(), directory, segmentInfo, fieldInfos, null, ioContext);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsFormatTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsFormatTests.java
@@ -4,6 +4,7 @@
  */
 package org.opensearch.neuralsearch.sparse.codec;
 
+import lombok.SneakyThrows;
 import org.apache.lucene.codecs.FieldsConsumer;
 import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.PostingsFormat;
@@ -31,7 +32,7 @@ public class SparsePostingsFormatTests extends AbstractSparseTestBase {
         mockDelegate = mock(PostingsFormat.class);
         when(mockDelegate.getName()).thenReturn("TestPostingsFormat");
 
-        sparsePostingsFormat = new SparsePostingsFormat(mockDelegate);
+        this.sparsePostingsFormat = new SparsePostingsFormat(mockDelegate);
 
         // Use TestsPrepareUtils to create real objects since SegmentInfo.name is final
         mockWriteState = TestsPrepareUtils.prepareSegmentWriteState();
@@ -40,17 +41,19 @@ public class SparsePostingsFormatTests extends AbstractSparseTestBase {
     }
 
     public void testConstructor() {
+        SparsePostingsFormat sparsePostingsFormat = new SparsePostingsFormat(mockDelegate);
         // Verify that the format name is inherited from delegate
         assertEquals("TestPostingsFormat", sparsePostingsFormat.getName());
     }
 
-    public void testFieldsConsumer() throws IOException {
+    @SneakyThrows
+    public void testFieldsConsumer() {
         // Setup
         FieldsConsumer mockDelegateConsumer = mock(FieldsConsumer.class);
         when(mockDelegate.fieldsConsumer(mockWriteState)).thenReturn(mockDelegateConsumer);
 
         // Execute
-        FieldsConsumer result = sparsePostingsFormat.fieldsConsumer(mockWriteState);
+        FieldsConsumer result = this.sparsePostingsFormat.fieldsConsumer(mockWriteState);
 
         // Verify
         assertNotNull(result);
@@ -58,13 +61,14 @@ public class SparsePostingsFormatTests extends AbstractSparseTestBase {
         verify(mockDelegate).fieldsConsumer(mockWriteState);
     }
 
-    public void testFieldsProducer() throws IOException {
+    @SneakyThrows
+    public void testFieldsProducer() {
         // Setup
         FieldsProducer mockDelegateProducer = mock(FieldsProducer.class);
         when(mockDelegate.fieldsProducer(mockReadState)).thenReturn(mockDelegateProducer);
 
         // Execute
-        FieldsProducer result = sparsePostingsFormat.fieldsProducer(mockReadState);
+        FieldsProducer result = this.sparsePostingsFormat.fieldsProducer(mockReadState);
 
         // Verify
         assertNotNull(result);
@@ -72,23 +76,25 @@ public class SparsePostingsFormatTests extends AbstractSparseTestBase {
         verify(mockDelegate).fieldsProducer(mockReadState);
     }
 
-    public void testFieldsConsumerIOException() throws IOException {
+    @SneakyThrows
+    public void testFieldsConsumerIOException() {
         // Setup
         IOException expectedException = new IOException("Test exception");
         when(mockDelegate.fieldsConsumer(mockWriteState)).thenThrow(expectedException);
 
         // Execute & Verify
-        IOException exception = expectThrows(IOException.class, () -> { sparsePostingsFormat.fieldsConsumer(mockWriteState); });
+        IOException exception = expectThrows(IOException.class, () -> { this.sparsePostingsFormat.fieldsConsumer(mockWriteState); });
         assertEquals("Test exception", exception.getMessage());
     }
 
-    public void testFieldsProducerIOException() throws IOException {
+    @SneakyThrows
+    public void testFieldsProducerIOException() {
         // Setup
         IOException expectedException = new IOException("Test exception");
         when(mockDelegate.fieldsProducer(mockReadState)).thenThrow(expectedException);
 
         // Execute & Verify
-        IOException exception = expectThrows(IOException.class, () -> { sparsePostingsFormat.fieldsProducer(mockReadState); });
+        IOException exception = expectThrows(IOException.class, () -> { this.sparsePostingsFormat.fieldsProducer(mockReadState); });
         assertEquals("Test exception", exception.getMessage());
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsFormatTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsFormatTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+public class SparsePostingsFormatTests extends AbstractSparseTestBase {
+
+    private PostingsFormat mockDelegate;
+    private SparsePostingsFormat sparsePostingsFormat;
+    private SegmentWriteState mockWriteState;
+    private SegmentReadState mockReadState;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mockDelegate = mock(PostingsFormat.class);
+        when(mockDelegate.getName()).thenReturn("TestPostingsFormat");
+
+        sparsePostingsFormat = new SparsePostingsFormat(mockDelegate);
+
+        // Use TestsPrepareUtils to create real objects since SegmentInfo.name is final
+        mockWriteState = TestsPrepareUtils.prepareSegmentWriteState();
+
+        mockReadState = mock(SegmentReadState.class);
+    }
+
+    public void testConstructor() {
+        // Verify that the format name is inherited from delegate
+        assertEquals("TestPostingsFormat", sparsePostingsFormat.getName());
+    }
+
+    public void testFieldsConsumer() throws IOException {
+        // Setup
+        FieldsConsumer mockDelegateConsumer = mock(FieldsConsumer.class);
+        when(mockDelegate.fieldsConsumer(mockWriteState)).thenReturn(mockDelegateConsumer);
+
+        // Execute
+        FieldsConsumer result = sparsePostingsFormat.fieldsConsumer(mockWriteState);
+
+        // Verify
+        assertNotNull(result);
+        assertTrue(result instanceof SparsePostingsConsumer);
+        verify(mockDelegate).fieldsConsumer(mockWriteState);
+    }
+
+    public void testFieldsProducer() throws IOException {
+        // Setup
+        FieldsProducer mockDelegateProducer = mock(FieldsProducer.class);
+        when(mockDelegate.fieldsProducer(mockReadState)).thenReturn(mockDelegateProducer);
+
+        // Execute
+        FieldsProducer result = sparsePostingsFormat.fieldsProducer(mockReadState);
+
+        // Verify
+        assertNotNull(result);
+        assertTrue(result instanceof SparsePostingsProducer);
+        verify(mockDelegate).fieldsProducer(mockReadState);
+    }
+
+    public void testFieldsConsumerIOException() throws IOException {
+        // Setup
+        IOException expectedException = new IOException("Test exception");
+        when(mockDelegate.fieldsConsumer(mockWriteState)).thenThrow(expectedException);
+
+        // Execute & Verify
+        IOException exception = expectThrows(IOException.class, () -> { sparsePostingsFormat.fieldsConsumer(mockWriteState); });
+        assertEquals("Test exception", exception.getMessage());
+    }
+
+    public void testFieldsProducerIOException() throws IOException {
+        // Setup
+        IOException expectedException = new IOException("Test exception");
+        when(mockDelegate.fieldsProducer(mockReadState)).thenThrow(expectedException);
+
+        // Execute & Verify
+        IOException exception = expectThrows(IOException.class, () -> { sparsePostingsFormat.fieldsProducer(mockReadState); });
+        assertEquals("Test exception", exception.getMessage());
+    }
+}


### PR DESCRIPTION
### Description
This PR creates unit tests for `org.opensearch.neuralsearch.sparse.codec.SparsePostingsFormat` class. It achieves 100% coverage.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
