### PR TITLE
Bug fix: Correct the ram bytes estimation on atomic reference array

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/cache/ForwardIndexCacheItem.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/cache/ForwardIndexCacheItem.java
@@ -35,7 +35,9 @@ public class ForwardIndexCacheItem implements SparseVectorForwardIndex, Accounta
         sparseVectors = new AtomicReferenceArray<>(docCount);
         // Account for the array itself in memory usage
         usedRamBytes = new AtomicLong(
-            RamUsageEstimator.shallowSizeOf(sparseVectors) + RamUsageEstimator.shallowSizeOf(new SparseVector[docCount])
+            RamUsageEstimator.shallowSizeOf(sparseVectors) + RamUsageEstimator.alignObjectSize(
+                (long) docCount * RamUsageEstimator.NUM_BYTES_OBJECT_REF
+            )
         );
         CircuitBreakerManager.addWithoutBreaking(usedRamBytes.get());
     }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/cache/ForwardIndexCacheItem.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/cache/ForwardIndexCacheItem.java
@@ -34,7 +34,9 @@ public class ForwardIndexCacheItem implements SparseVectorForwardIndex, Accounta
     public ForwardIndexCacheItem(int docCount) {
         sparseVectors = new AtomicReferenceArray<>(docCount);
         // Account for the array itself in memory usage
-        usedRamBytes = new AtomicLong(RamUsageEstimator.shallowSizeOf(sparseVectors));
+        usedRamBytes = new AtomicLong(
+            RamUsageEstimator.shallowSizeOf(sparseVectors) + (long) docCount * RamUsageEstimator.NUM_BYTES_OBJECT_REF
+        );
         CircuitBreakerManager.addWithoutBreaking(usedRamBytes.get());
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/sparse/cache/ForwardIndexCacheItem.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/cache/ForwardIndexCacheItem.java
@@ -35,7 +35,7 @@ public class ForwardIndexCacheItem implements SparseVectorForwardIndex, Accounta
         sparseVectors = new AtomicReferenceArray<>(docCount);
         // Account for the array itself in memory usage
         usedRamBytes = new AtomicLong(
-            RamUsageEstimator.shallowSizeOf(sparseVectors) + (long) docCount * RamUsageEstimator.NUM_BYTES_OBJECT_REF
+            RamUsageEstimator.shallowSizeOf(sparseVectors) + RamUsageEstimator.shallowSizeOf(new SparseVector[docCount])
         );
         CircuitBreakerManager.addWithoutBreaking(usedRamBytes.get());
     }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/cache/ForwardIndexCacheItemTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/cache/ForwardIndexCacheItemTests.java
@@ -247,6 +247,22 @@ public class ForwardIndexCacheItemTests extends AbstractSparseTestBase {
     }
 
     /**
+     * Tests that ramBytesUsed correctly records the memory on the sparse vector array
+     */
+    @SneakyThrows
+    public void test_ramBytesUsed_withDifferentVectorSize() {
+        int docCount1 = 10, docCount2 = 20;
+        ForwardIndexCacheItem cacheItem = ForwardIndexCache.getInstance().getOrCreate(cacheKey, docCount1);
+        long ramBytesUsed1 = cacheItem.ramBytesUsed();
+
+        ForwardIndexCache.getInstance().removeIndex(cacheKey);
+        cacheItem = ForwardIndexCache.getInstance().getOrCreate(cacheKey, docCount2);
+        long ramBytesUsed2 = cacheItem.ramBytesUsed();
+
+        assertTrue("Initial RAM usage should increase when the size of forward index increases", ramBytesUsed2 > ramBytesUsed1);
+    }
+
+    /**
      * Tests that ramBytesUsed correctly reports the memory usage after vectors are inserted.
      * This verifies the memory tracking functionality of the ForwardIndexCacheItem.
      */


### PR DESCRIPTION
### Description
This PR fixes a bug so that we can correctly estimate the ram bytes used for atomic reference array in the forward index. This bug is due to the memory stats PR (https://github.com/chishui/neural-search/pull/73/files), where the sparseVectors data structure changes from **SparseVector[]** to **AtomicReferenceArray<SparseVector>**.

Previous implementation

```
private final SparseVector[] sparseVectors;
private final AtomicLong usedRamBytes = new AtomicLong(0);

public InMemorySparseVectorForwardIndex(int docCount) {
    sparseVectors = new SparseVector[docCount];
    usedRamBytes.set(RamUsageEstimator.shallowSizeOf(sparseVectors));
}
```

Current implementation 

```
private final AtomicReferenceArray<SparseVector> sparseVectors;
private final AtomicLong usedRamBytes = new AtomicLong(0);

public InMemorySparseVectorForwardIndex(int docCount) {
    sparseVectors = new AtomicReferenceArray<>(docCount);
    usedRamBytes.set(RamUsageEstimator.shallowSizeOf(sparseVectors));
}
```

Unfortunately, the RamUsageEstimator.shallowSizeOf function returns different results by these two implementations. The following code snippets return different results:

```
SparseVector[] sparseVectorList = new SparseVector[1024];
AtomicReferenceArray<SparseVector> atomicSparseVectorList = new AtomicReferenceArray<>(1024);
long listSize = RamUsageEstimator.shallowSizeOf(sparseVectorList);
long atomicListSize = RamUsageEstimator.shallowSizeOf(atomicSparseVectorList);
```

where listSize is **4112** and atomicListSize is **16**.
I referred to the code of the RamUsageEstimator, can find out that the size can be correctly estimated by:

```
int referenceSize = RamUsageEstimator.NUM_BYTES_OBJECT_REF; // 4 or 8 depending on JVM
long manualAtomicSize = RamUsageEstimator.shallowSizeOf(atomicSparseVectorList) + referenceSize * 1024;
```





### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
