### PR TITLE
[Feat] Add A Consumer to CacheItems

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/cache/ClusteredPostingCacheItem.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/cache/ClusteredPostingCacheItem.java
@@ -42,7 +42,6 @@ public class ClusteredPostingCacheItem implements Accountable {
      * @return the ClusteredPostingWriter instance
      */
     public ClusteredPostingWriter getWriter(Consumer<Long> circuitBreakerHandler) {
-
         return new CacheClusteredPostingWriter(circuitBreakerHandler);
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/sparse/cache/ClusteredPostingCacheItem.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/cache/ClusteredPostingCacheItem.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 
 /**
  * This class manages the cache postings for sparse vectors. It provides methods to write and read postings from cache.
@@ -34,6 +35,16 @@ public class ClusteredPostingCacheItem implements Accountable {
     private final ClusteredPostingReader reader = new CacheClusteredPostingReader();
     @Getter
     private final ClusteredPostingWriter writer = new CacheClusteredPostingWriter();
+
+    /**
+     * Returns the writer instance.
+     * @param circuitBreakerHandler A consumer to handle circuit breaker triggering differently
+     * @return the ClusteredPostingWriter instance
+     */
+    public ClusteredPostingWriter getWriter(Consumer<Long> circuitBreakerHandler) {
+
+        return new CacheClusteredPostingWriter(circuitBreakerHandler);
+    }
 
     public ClusteredPostingCacheItem() {
         CircuitBreakerManager.addWithoutBreaking(usedRamBytes.get());
@@ -64,6 +75,16 @@ public class ClusteredPostingCacheItem implements Accountable {
     }
 
     private class CacheClusteredPostingWriter implements ClusteredPostingWriter {
+        private final Consumer<Long> circuitBreakerTriggerHandler;
+
+        private CacheClusteredPostingWriter(Consumer<Long> circuitBreakerTriggerHandler) {
+            this.circuitBreakerTriggerHandler = circuitBreakerTriggerHandler;
+        }
+
+        private CacheClusteredPostingWriter() {
+            this.circuitBreakerTriggerHandler = null;
+        }
+
         public void insert(BytesRef term, List<DocumentCluster> clusters) {
             if (clusters == null || clusters.isEmpty() || term == null) {
                 return;
@@ -77,6 +98,9 @@ public class ClusteredPostingCacheItem implements Accountable {
 
             if (!CircuitBreakerManager.addMemoryUsage(ramBytesUsed, CIRCUIT_BREAKER_LABEL)) {
                 // TODO: cache eviction
+                if (circuitBreakerTriggerHandler != null) {
+                    circuitBreakerTriggerHandler.accept(ramBytesUsed);
+                }
                 return;
             }
 

--- a/src/main/java/org/opensearch/neuralsearch/sparse/cache/ForwardIndexCacheItem.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/cache/ForwardIndexCacheItem.java
@@ -38,7 +38,6 @@ public class ForwardIndexCacheItem implements SparseVectorForwardIndex, Accounta
      * @return the SparseVectorWriter instance
      */
     public SparseVectorWriter getWriter(Consumer<Long> circuitBreakerHandler) {
-
         return new CacheSparseVectorWriter(circuitBreakerHandler);
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/sparse/cache/ForwardIndexCacheItem.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/cache/ForwardIndexCacheItem.java
@@ -16,6 +16,7 @@ import org.opensearch.neuralsearch.sparse.data.SparseVector;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.Consumer;
 
 /**
  * This class is used to store/read sparse vector in cache
@@ -30,6 +31,16 @@ public class ForwardIndexCacheItem implements SparseVectorForwardIndex, Accounta
     private final SparseVectorReader reader = new CacheSparseVectorReader();
     @Getter
     private final SparseVectorWriter writer = new CacheSparseVectorWriter();
+
+    /**
+     * Returns the writer instance.
+     * @param circuitBreakerHandler A consumer to handle circuit breaker triggering differently
+     * @return the SparseVectorWriter instance
+     */
+    public SparseVectorWriter getWriter(Consumer<Long> circuitBreakerHandler) {
+
+        return new CacheSparseVectorWriter(circuitBreakerHandler);
+    }
 
     public ForwardIndexCacheItem(int docCount) {
         sparseVectors = new AtomicReferenceArray<>(docCount);
@@ -54,6 +65,15 @@ public class ForwardIndexCacheItem implements SparseVectorForwardIndex, Accounta
     }
 
     private class CacheSparseVectorWriter implements SparseVectorWriter {
+        private final Consumer<Long> circuitBreakerTriggerHandler;
+
+        private CacheSparseVectorWriter(Consumer<Long> circuitBreakerTriggerHandler) {
+            this.circuitBreakerTriggerHandler = circuitBreakerTriggerHandler;
+        }
+
+        private CacheSparseVectorWriter() {
+            this.circuitBreakerTriggerHandler = null;
+        }
 
         @Override
         public void insert(int docId, SparseVector vector) {
@@ -65,6 +85,9 @@ public class ForwardIndexCacheItem implements SparseVectorForwardIndex, Accounta
 
             if (!CircuitBreakerManager.addMemoryUsage(ramBytesUsed, CIRCUIT_BREAKER_LABEL)) {
                 // TODO: cache eviction
+                if (circuitBreakerTriggerHandler != null) {
+                    circuitBreakerTriggerHandler.accept(ramBytesUsed);
+                }
                 return;
             }
 


### PR DESCRIPTION
### Description
We need different way to handle circuit breaker triggering. Sometimes we need to do cache eviction, while sometimes we need to throw an exception to notify that the circuit breaker is triggering. So, I added `Consumer` to `CacheClusteredPostingWriter ` and `CacheSparseVectorWriter `. In this way, we can implement both LRU logic and throwing exception logic when we call `getWriter()`.

We can first merge this PR before we merge LRU and warm up.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
