### PR TITLE
UT for SparseBinaryDocValuesPassThrough

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesPassThrough.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesPassThrough.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 
 @AllArgsConstructor
 public class SparseBinaryDocValuesPassThrough extends BinaryDocValues implements SparseVectorReader {
+
     private final BinaryDocValues delegate;
     @Getter
     private final SegmentInfo segmentInfo;

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesPassThroughTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesPassThroughTests.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.util.BytesRef;
+import org.junit.Before;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
+import org.opensearch.neuralsearch.sparse.data.SparseVector;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
+
+public class SparseBinaryDocValuesPassThroughTests extends AbstractSparseTestBase {
+
+    private BinaryDocValues mockDelegate;
+    private SegmentInfo mockSegmentInfo;
+    private SparseBinaryDocValuesPassThrough sparseBinaryDocValuesPassThrough;
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        mockDelegate = mock(BinaryDocValues.class);
+        mockSegmentInfo = mock(SegmentInfo.class);
+        sparseBinaryDocValuesPassThrough = new SparseBinaryDocValuesPassThrough(mockDelegate, mockSegmentInfo);
+    }
+
+    public void testConstructor_InitializesFieldsCorrectly() {
+        SparseBinaryDocValuesPassThrough sparseBinaryDocValuesPassThrough = new SparseBinaryDocValuesPassThrough(
+            mockDelegate,
+            mockSegmentInfo
+        );
+
+        assertSame(mockSegmentInfo, sparseBinaryDocValuesPassThrough.getSegmentInfo());
+    }
+
+    public void testGetSegmentInfo() {
+        SegmentInfo result = sparseBinaryDocValuesPassThrough.getSegmentInfo();
+
+        assertEquals(mockSegmentInfo, result);
+    }
+
+    public void testBinaryValue() throws IOException {
+        BytesRef expectedBytesRef = new BytesRef("test_binary_value");
+        when(mockDelegate.binaryValue()).thenReturn(expectedBytesRef);
+
+        BytesRef result = sparseBinaryDocValuesPassThrough.binaryValue();
+
+        assertEquals(expectedBytesRef, result);
+        verify(mockDelegate, times(1)).binaryValue();
+    }
+
+    public void testAdvanceExact() throws IOException {
+        int targetDoc = 1;
+        when(mockDelegate.advanceExact(targetDoc)).thenReturn(true);
+
+        boolean result = sparseBinaryDocValuesPassThrough.advanceExact(targetDoc);
+
+        assertTrue(result);
+        verify(mockDelegate, times(1)).advanceExact(targetDoc);
+    }
+
+    public void testDocID() {
+        int expectedDocId = 1;
+        when(mockDelegate.docID()).thenReturn(expectedDocId);
+
+        int result = sparseBinaryDocValuesPassThrough.docID();
+
+        assertEquals(expectedDocId, result);
+        verify(mockDelegate, times(1)).docID();
+    }
+
+    public void testNextDoc() throws IOException {
+        int expectedNextDoc = 1;
+        when(mockDelegate.nextDoc()).thenReturn(expectedNextDoc);
+
+        int result = sparseBinaryDocValuesPassThrough.nextDoc();
+
+        assertEquals(expectedNextDoc, result);
+        verify(mockDelegate, times(1)).nextDoc();
+    }
+
+    public void testAdvance() throws IOException {
+        int targetDoc = 1;
+        int expectedAdvancedDoc = 2;
+        when(mockDelegate.advance(targetDoc)).thenReturn(expectedAdvancedDoc);
+
+        int result = sparseBinaryDocValuesPassThrough.advance(targetDoc);
+
+        assertEquals(expectedAdvancedDoc, result);
+        verify(mockDelegate, times(1)).advance(targetDoc);
+    }
+
+    public void testCost() {
+        long expectedCost = 1000L;
+        when(mockDelegate.cost()).thenReturn(expectedCost);
+
+        long result = sparseBinaryDocValuesPassThrough.cost();
+
+        assertEquals(expectedCost, result);
+        verify(mockDelegate, times(1)).cost();
+    }
+
+    public void testRead_WhenAdvanceExactReturnsFalse() throws IOException {
+        int docId = 1;
+        when(mockDelegate.advanceExact(docId)).thenReturn(false);
+
+        SparseVector result = sparseBinaryDocValuesPassThrough.read(docId);
+
+        assertNull(result);
+        verify(mockDelegate, times(1)).advanceExact(docId);
+        verify(mockDelegate, never()).binaryValue();
+    }
+
+    public void testRead_WhenBinaryValueReturnsNull() throws IOException {
+        int docId = 1;
+        when(mockDelegate.advanceExact(docId)).thenReturn(true);
+        when(mockDelegate.binaryValue()).thenReturn(null);
+
+        SparseVector result = sparseBinaryDocValuesPassThrough.read(docId);
+
+        assertNull(result);
+        verify(mockDelegate, times(1)).advanceExact(docId);
+        verify(mockDelegate, times(1)).binaryValue();
+    }
+
+    public void testRead_WhenBinaryValueReturnsBytesRef() throws IOException {
+        int docId = 42;
+        BytesRef bytesRef = TestsPrepareUtils.prepareValidSparseVectorBytes();
+        when(mockDelegate.advanceExact(docId)).thenReturn(true);
+        when(mockDelegate.binaryValue()).thenReturn(bytesRef);
+
+        SparseVector result = sparseBinaryDocValuesPassThrough.read(docId);
+
+        assertNotNull(result);
+        verify(mockDelegate, times(1)).advanceExact(docId);
+        verify(mockDelegate, times(1)).binaryValue();
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces UT for SparseBinaryDocValuesPassThrough, which achieves 100% test coverage.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
