### PR TITLE
Fix: avoid multiple creation for readerSupplier

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsProducer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsProducer.java
@@ -70,7 +70,9 @@ public class SparsePostingsProducer extends FieldsProducer {
             return delegate.terms(field);
         }
         CacheKey key = new CacheKey(this.state.segmentInfo, fieldInfo);
-        reader = readerSupplier.get();
+        if (reader == null) {
+            reader = readerSupplier.get();
+        }
         return new SparseTerms(key, reader, field);
     }
 


### PR DESCRIPTION
### Description
This PR fixes the bug to avoid multiple creation from supplier 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
