### PR TITLE
UT: SparsePostingsEnum and SparsePostingsConsumer

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/sparse/TestsPrepareUtils.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/TestsPrepareUtils.java
@@ -567,6 +567,13 @@ public class TestsPrepareUtils {
         return new SegmentWriteState(InfoStream.getDefault(), directory, segmentInfo, fieldInfos, null, ioContext);
     }
 
+    public static SegmentWriteState prepareSegmentWriteState(Directory directory, FieldInfos fieldInfos) {
+        SegmentInfo segmentInfo = prepareSegmentInfo();
+        IOContext ioContext = IOContext.DEFAULT;
+
+        return new SegmentWriteState(InfoStream.getDefault(), directory, segmentInfo, fieldInfos, null, ioContext);
+    }
+
     public static BytesRef prepareValidSparseVectorBytes() {
         // Create a valid sparse vector BytesRef with token "1" -> 0.5f
         try {

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumerTests.java
@@ -29,8 +29,10 @@ import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
 import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -185,9 +187,12 @@ public class SparsePostingsConsumerTests extends AbstractSparseTestBase {
         SparseTermsLuceneWriter sparseTermsWriter = sparseTermsWriters.get(0);
 
         // Setup field info with sparse fields
-        FieldInfo mockFieldInfo = TestsPrepareUtils.prepareKeyFieldInfo();
-        mockFieldInfo.attributes().put(APPROXIMATE_THRESHOLD_FIELD, String.valueOf(1));
-        mockFieldInfo.attributes().put(SPARSE_FIELD, String.valueOf(true));
+        FieldInfo mockFieldInfo = mock(FieldInfo.class);
+        when(mockFieldInfo.getName()).thenReturn(SPARSE_FIELD);
+        Map<String, String> sparseAttributes = new HashMap<>();
+        sparseAttributes.put(SPARSE_FIELD, String.valueOf(true));
+        sparseAttributes.put(APPROXIMATE_THRESHOLD_FIELD, String.valueOf(1));
+        when(mockFieldInfo.attributes()).thenReturn(sparseAttributes);
 
         // Setup fieldInfos mock
         when(mockFieldInfos.fieldInfo(anyString())).thenReturn(mockFieldInfo);
@@ -222,9 +227,12 @@ public class SparsePostingsConsumerTests extends AbstractSparseTestBase {
         SparseTermsLuceneWriter sparseTermsWriter = sparseTermsWriters.get(0);
 
         // Setup field info with sparse fields
-        FieldInfo mockFieldInfo = TestsPrepareUtils.prepareKeyFieldInfo();
-        mockFieldInfo.attributes().put(APPROXIMATE_THRESHOLD_FIELD, String.valueOf(1));
-        mockFieldInfo.attributes().put(SPARSE_FIELD, String.valueOf(true));
+        FieldInfo mockFieldInfo = mock(FieldInfo.class);
+        when(mockFieldInfo.getName()).thenReturn(SPARSE_FIELD);
+        Map<String, String> sparseAttributes = new HashMap<>();
+        sparseAttributes.put(SPARSE_FIELD, String.valueOf(true));
+        sparseAttributes.put(APPROXIMATE_THRESHOLD_FIELD, String.valueOf(1));
+        when(mockFieldInfo.attributes()).thenReturn(sparseAttributes);
 
         // Setup fieldInfos mock
         when(mockFieldInfos.fieldInfo(anyString())).thenReturn(mockFieldInfo);

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumerTests.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.codecs.BlockTermState;
+import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.NormsProducer;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.BytesRef;
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.SparseTokensField;
+import org.opensearch.neuralsearch.sparse.common.MergeStateFacade;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SparsePostingsConsumerTests extends AbstractSparseTestBase {
+
+    private SparsePostingsConsumer sparsePostingsConsumer;
+    private FieldsConsumer delegateConsumer;
+    private SegmentWriteState segmentWriteState;
+    private Directory directory;
+    private IndexOutput termsOutput;
+    private IndexOutput postingOutput;
+    private FieldInfo sparseFieldInfo;
+    private FieldInfo nonSparseFieldInfo;
+    private Fields fields;
+    private NormsProducer normsProducer;
+    private MergeState mergeState;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        // Mock dependencies
+        delegateConsumer = mock(FieldsConsumer.class);
+        segmentWriteState = mock(SegmentWriteState.class);
+        directory = mock(Directory.class);
+        termsOutput = mock(IndexOutput.class);
+        postingOutput = mock(IndexOutput.class);
+        fields = mock(Fields.class);
+        normsProducer = mock(NormsProducer.class);
+        mergeState = mock(MergeState.class);
+
+        // Setup segment info
+        SegmentInfo segmentInfo = mock(SegmentInfo.class);
+        when(segmentInfo.name).thenReturn("test_segment");
+        when(segmentWriteState.segmentInfo).thenReturn(segmentInfo);
+        when(segmentWriteState.directory).thenReturn(directory);
+        when(segmentWriteState.segmentSuffix).thenReturn("suffix");
+        when(segmentWriteState.context).thenReturn(null);
+
+        // Setup field infos
+        FieldInfos fieldInfos = mock(FieldInfos.class);
+        when(segmentWriteState.fieldInfos).thenReturn(fieldInfos);
+
+        // Setup sparse field
+        sparseFieldInfo = mock(FieldInfo.class);
+        Map<String, String> sparseAttributes = new HashMap<>();
+        sparseAttributes.put(SparseTokensField.SPARSE_FIELD, "true");
+        when(sparseFieldInfo.attributes()).thenReturn(sparseAttributes);
+        when(sparseFieldInfo.name).thenReturn("sparse_field");
+        when(sparseFieldInfo.number).thenReturn(1);
+        when(fieldInfos.fieldInfo("sparse_field")).thenReturn(sparseFieldInfo);
+
+        // Setup non-sparse field
+        nonSparseFieldInfo = mock(FieldInfo.class);
+        when(nonSparseFieldInfo.attributes()).thenReturn(new HashMap<>());
+        when(nonSparseFieldInfo.name).thenReturn("non_sparse_field");
+        when(nonSparseFieldInfo.number).thenReturn(2);
+        when(fieldInfos.fieldInfo("non_sparse_field")).thenReturn(nonSparseFieldInfo);
+
+        // Setup directory outputs
+        when(directory.createOutput(any(), any())).thenReturn(termsOutput, postingOutput);
+        when(termsOutput.getFilePointer()).thenReturn(0L);
+        when(postingOutput.getFilePointer()).thenReturn(0L);
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    public void testConstructor() throws IOException {
+        // Test constructor with version parameter
+        SparsePostingsConsumer consumer = new SparsePostingsConsumer(delegateConsumer, segmentWriteState, 1);
+        assertNotNull(consumer);
+    }
+
+    public void testWriteWithNoSparseFields() throws IOException {
+        // Create the consumer
+        sparsePostingsConsumer = new SparsePostingsConsumer(delegateConsumer, segmentWriteState);
+
+        // Setup fields with only non-sparse fields
+        List<String> fieldNames = new ArrayList<>();
+        fieldNames.add("non_sparse_field");
+        when(fields.iterator()).thenReturn(fieldNames.iterator());
+
+        sparsePostingsConsumer.write(fields, normsProducer);
+
+        // Verify delegate was called with the same fields
+        verify(delegateConsumer, times(1)).write(any(Fields.class), any(NormsProducer.class));
+    }
+
+    public void testWriteWithSparseFields() throws IOException {
+        // Create a spy of SparsePostingsConsumer to mock internal methods
+        sparsePostingsConsumer = spy(new SparsePostingsConsumer(delegateConsumer, segmentWriteState));
+
+        // Setup fields with both sparse and non-sparse fields
+        List<String> fieldNames = new ArrayList<>();
+        fieldNames.add("sparse_field");
+        fieldNames.add("non_sparse_field");
+        when(fields.iterator()).thenReturn(fieldNames.iterator());
+
+        // Setup Terms for sparse field
+        Terms terms = mock(Terms.class);
+        when(fields.terms("sparse_field")).thenReturn(terms);
+
+        // Setup TermsEnum
+        TermsEnum termsEnum = mock(TermsEnum.class);
+        when(terms.iterator()).thenReturn(termsEnum);
+        when(termsEnum.next()).thenReturn(new BytesRef("term1"), null);
+
+        // Setup BlockTermState
+        BlockTermState blockTermState = mock(BlockTermState.class);
+
+        // Mock internal methods
+        doNothing().when(sparsePostingsConsumer).initWriters();
+        doNothing().when(sparsePostingsConsumer).writeFieldCount(anyInt());
+        doNothing().when(sparsePostingsConsumer).writeFieldNumber(anyInt());
+        doNothing().when(sparsePostingsConsumer).writeTermsSize(anyInt());
+        doReturn(blockTermState).when(sparsePostingsConsumer).writeTerm(any(BytesRef.class), any(TermsEnum.class), any(NormsProducer.class));
+
+        sparsePostingsConsumer.write(fields, normsProducer);
+
+        // Verify delegate was called with filtered fields (non-sparse only)
+        verify(delegateConsumer, times(1)).write(any(FilterLeafReader.FilterFields.class), any(NormsProducer.class));
+
+        // Verify sparse terms were written
+        verify(sparsePostingsConsumer, times(1)).writeFieldCount(1);
+        verify(sparsePostingsConsumer, times(1)).writeFieldNumber(1);
+        verify(sparsePostingsConsumer, times(1)).writeTermsSize(1);
+        verify(sparsePostingsConsumer, times(1)).writeTerm(any(BytesRef.class), any(TermsEnum.class), any(NormsProducer.class));
+    }
+
+    public void testMerge() throws IOException {
+        // Create a spy of SparsePostingsConsumer to mock internal methods
+        sparsePostingsConsumer = spy(new SparsePostingsConsumer(delegateConsumer, segmentWriteState));
+
+        // Setup merge state
+        when(mergeState.segmentInfo).thenReturn(segmentWriteState.segmentInfo);
+
+        // Mock internal methods
+        doNothing().when(sparsePostingsConsumer).initWriters();
+        doNothing().when(sparsePostingsConsumer).mergeSparseSectors(any(MergeState.class), any(NormsProducer.class));
+
+        sparsePostingsConsumer.merge(mergeState, normsProducer);
+
+        // Verify delegate merge was called
+        verify(delegateConsumer, times(1)).merge(mergeState, normsProducer);
+
+        // Verify merge method was called
+        verify(sparsePostingsConsumer, times(1)).mergeSparseSectors(mergeState, normsProducer);
+    }
+
+    public void testClose() throws IOException {
+        // Create a spy of SparsePostingsConsumer to mock internal methods
+        sparsePostingsConsumer = spy(new SparsePostingsConsumer(delegateConsumer, segmentWriteState));
+
+        // Mock internal methods
+        doNothing().when(sparsePostingsConsumer).closeWriters(anyLong(), anyLong());
+
+        sparsePostingsConsumer.close();
+
+        // Verify delegate close was called
+        verify(delegateConsumer, times(1)).close();
+
+        // Verify writers were closed
+        verify(sparsePostingsConsumer, times(1)).closeWriters(anyLong(), anyLong());
+    }
+
+    public void testMergeWithException() throws IOException {
+        // Create a spy of SparsePostingsConsumer to mock internal methods
+        sparsePostingsConsumer = spy(new SparsePostingsConsumer(delegateConsumer, segmentWriteState));
+
+        // Setup merge state
+        when(mergeState.segmentInfo).thenReturn(segmentWriteState.segmentInfo);
+
+        // Mock internal methods to throw exception
+        doNothing().when(sparsePostingsConsumer).initWriters();
+        doThrow(new IOException("Test exception")).when(sparsePostingsConsumer).mergeSparseSectors(any(MergeState.class), any(NormsProducer.class));
+
+        // Should not throw exception, just log error
+        sparsePostingsConsumer.merge(mergeState, normsProducer);
+
+        // Verify delegate merge was still called
+        verify(delegateConsumer, times(1)).merge(mergeState, normsProducer);
+    }
+
+    public void testWriteWithEmptySparseTerms() throws IOException {
+        // Create a spy of SparsePostingsConsumer to mock internal methods
+        sparsePostingsConsumer = spy(new SparsePostingsConsumer(delegateConsumer, segmentWriteState));
+
+        // Setup fields with sparse field
+        List<String> fieldNames = new ArrayList<>();
+        fieldNames.add("sparse_field");
+        when(fields.iterator()).thenReturn(fieldNames.iterator());
+
+        // Return null for terms to simulate empty terms
+        when(fields.terms("sparse_field")).thenReturn(null);
+
+        // Mock internal methods
+        doNothing().when(sparsePostingsConsumer).initWriters();
+        doNothing().when(sparsePostingsConsumer).writeFieldCount(anyInt());
+        doNothing().when(sparsePostingsConsumer).writeFieldNumber(anyInt());
+        doNothing().when(sparsePostingsConsumer).writeTermsSize(anyInt());
+
+        sparsePostingsConsumer.write(fields, normsProducer);
+
+        // Verify sparse terms size was written as 0
+        verify(sparsePostingsConsumer, times(1)).writeTermsSize(0);
+    }
+
+    public void testWriteFromMerge() throws IOException {
+        // Create a spy of SparsePostingsConsumer to mock internal methods
+        sparsePostingsConsumer = spy(new SparsePostingsConsumer(delegateConsumer, segmentWriteState));
+
+        // Setup fields with sparse field
+        List<String> fieldNames = new ArrayList<>();
+        fieldNames.add("sparse_field");
+        when(fields.iterator()).thenReturn(fieldNames.iterator());
+
+        // Set fromMerge flag to true by calling merge first
+        doNothing().when(sparsePostingsConsumer).initWriters();
+        doNothing().when(sparsePostingsConsumer).mergeSparseSectors(any(MergeState.class), any(NormsProducer.class));
+        sparsePostingsConsumer.merge(mergeState, normsProducer);
+
+        // Now call write - it should not process sparse fields
+        sparsePostingsConsumer.write(fields, normsProducer);
+
+        // Verify sparse terms were not written (since fromMerge is true)
+        verify(sparsePostingsConsumer, times(0)).writeFieldCount(anyInt());
+    }
+
+    public void testIteratorFiltering() throws IOException {
+        // Create the consumer
+        sparsePostingsConsumer = new SparsePostingsConsumer(delegateConsumer, segmentWriteState);
+
+        // Setup fields with both sparse and non-sparse fields
+        List<String> fieldNames = new ArrayList<>();
+        fieldNames.add("sparse_field");
+        fieldNames.add("non_sparse_field");
+        when(fields.iterator()).thenReturn(fieldNames.iterator());
+
+        // Capture the filtered iterator to verify filtering
+        final List<String> capturedFields = new ArrayList<>();
+        when(delegateConsumer.write(any(Fields.class), any(NormsProducer.class))).thenAnswer(invocation -> {
+            Fields filteredFields = invocation.getArgument(0);
+            Iterator<String> iterator = filteredFields.iterator();
+            while (iterator.hasNext()) {
+                capturedFields.add(iterator.next());
+            }
+            return null;
+        });
+
+        sparsePostingsConsumer.write(fields, normsProducer);
+
+        // Verify only non-sparse fields were passed to delegate
+        assertEquals(1, capturedFields.size());
+        assertEquals("non_sparse_field", capturedFields.get(0));
+    }
+
+    public void testWriteWithMultipleSparseFields() throws IOException {
+        // Create a spy of SparsePostingsConsumer to mock internal methods
+        sparsePostingsConsumer = spy(new SparsePostingsConsumer(delegateConsumer, segmentWriteState));
+
+        // Setup two sparse fields
+        List<String> fieldNames = new ArrayList<>();
+        fieldNames.add("sparse_field");
+        fieldNames.add("sparse_field2");
+        when(fields.iterator()).thenReturn(fieldNames.iterator());
+
+        // Setup second sparse field info
+        FieldInfo sparseFieldInfo2 = mock(FieldInfo.class);
+        Map<String, String> sparseAttributes2 = new HashMap<>();
+        sparseAttributes2.put(SparseTokensField.SPARSE_FIELD, "true");
+        when(sparseFieldInfo2.attributes()).thenReturn(sparseAttributes2);
+        when(sparseFieldInfo2.name).thenReturn("sparse_field2");
+        when(sparseFieldInfo2.number).thenReturn(3);
+        when(segmentWriteState.fieldInfos.fieldInfo("sparse_field2")).thenReturn(sparseFieldInfo2);
+
+        // Setup Terms for both sparse fields
+        Terms terms1 = mock(Terms.class);
+        Terms terms2 = mock(Terms.class);
+        when(fields.terms("sparse_field")).thenReturn(terms1);
+        when(fields.terms("sparse_field2")).thenReturn(terms2);
+
+        // Setup TermsEnum for both fields
+        TermsEnum termsEnum1 = mock(TermsEnum.class);
+        TermsEnum termsEnum2 = mock(TermsEnum.class);
+        when(terms1.iterator()).thenReturn(termsEnum1);
+        when(terms2.iterator()).thenReturn(termsEnum2);
+        when(termsEnum1.next()).thenReturn(new BytesRef("term1"), null);
+        when(termsEnum2.next()).thenReturn(new BytesRef("term2"), null);
+
+        // Setup BlockTermState
+        BlockTermState blockTermState = mock(BlockTermState.class);
+
+        // Mock internal methods
+        doNothing().when(sparsePostingsConsumer).initWriters();
+        doNothing().when(sparsePostingsConsumer).writeFieldCount(anyInt());
+        doNothing().when(sparsePostingsConsumer).writeFieldNumber(anyInt());
+        doNothing().when(sparsePostingsConsumer).writeTermsSize(anyInt());
+        doReturn(blockTermState).when(sparsePostingsConsumer).writeTerm(any(BytesRef.class), any(TermsEnum.class), any(NormsProducer.class));
+
+        sparsePostingsConsumer.write(fields, normsProducer);
+
+        // Verify field count is 2
+        verify(sparsePostingsConsumer, times(1)).writeFieldCount(2);
+
+        // Verify both field numbers were written
+        verify(sparsePostingsConsumer, times(1)).writeFieldNumber(1);
+        verify(sparsePostingsConsumer, times(1)).writeFieldNumber(3);
+
+        // Verify terms size was written for both fields
+        verify(sparsePostingsConsumer, times(2)).writeTermsSize(1);
+
+        // Verify terms were written for both fields
+        verify(sparsePostingsConsumer, times(2)).writeTerm(any(BytesRef.class), any(TermsEnum.class), any(NormsProducer.class));
+    }
+
+    public void testMergeSparseSectors() throws IOException {
+        // Create a spy of SparsePostingsConsumer to mock internal methods
+        sparsePostingsConsumer = spy(new SparsePostingsConsumer(delegateConsumer, segmentWriteState));
+
+        // Setup merge state with sparse fields
+        MergeStateFacade mergeStateFacade = mock(MergeStateFacade.class);
+        when(mergeStateFacade.getNumSparseFields()).thenReturn(1);
+        when(mergeStateFacade.getSparseFieldNumber(0)).thenReturn(1);
+        when(mergeStateFacade.getSparseFieldName(0)).thenReturn("sparse_field");
+        when(mergeStateFacade.getNumTerms(0)).thenReturn(1);
+        when(mergeStateFacade.getTerm(0, 0)).thenReturn(new BytesRef("term1"));
+
+        // Mock internal methods
+        doReturn(mergeStateFacade).when(sparsePostingsConsumer).createMergeStateFacade(any(MergeState.class));
+        doNothing().when(sparsePostingsConsumer).writeFieldCount(anyInt());
+        doNothing().when(sparsePostingsConsumer).writeFieldNumber(anyInt());
+        doNothing().when(sparsePostingsConsumer).writeTermsSize(anyInt());
+        doNothing().when(sparsePostingsConsumer).writeMergedTerm(any(BytesRef.class), any(MergeStateFacade.class), anyInt(), anyInt(), any(NormsProducer.class));
+
+        // Call the method directly
+        sparsePostingsConsumer.mergeSparseSectors(mergeState, normsProducer);
+
+        // Verify merge operations
+        verify(sparsePostingsConsumer, times(1)).writeFieldCount(1);
+        verify(sparsePostingsConsumer, times(1)).writeFieldNumber(1);
+        verify(sparsePostingsConsumer, times(1)).writeTermsSize(1);
+        verify(sparsePostingsConsumer, times(1)).writeMergedTerm(any(BytesRef.class), any(MergeStateFacade.class), anyInt(), anyInt(), any(NormsProducer.class));
+    }
+
+    public void testInitWriters() throws IOException {
+        // Create a spy of SparsePostingsConsumer
+        sparsePostingsConsumer = spy(new SparsePostingsConsumer(delegateConsumer, segmentWriteState));
+
+        // Call the method directly
+        sparsePostingsConsumer.initWriters();
+
+        // Verify directory.createOutput was called twice
+        verify(directory, times(2)).createOutput(any(), any());
+    }
+
+    public void testCloseWriters() throws IOException {
+        // Create a spy of SparsePostingsConsumer
+        sparsePostingsConsumer = spy(new SparsePostingsConsumer(delegateConsumer, segmentWriteState));
+
+        // Initialize writers first
+        sparsePostingsConsumer.initWriters();
+
+        // Call the method directly
+        sparsePostingsConsumer.closeWriters(0L, 0L);
+
+        // Verify outputs were closed
+        verify(termsOutput, times(1)).close();
+        verify(postingOutput, times(1)).close();
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumerTests.java
@@ -49,6 +49,8 @@ import static org.opensearch.neuralsearch.sparse.mapper.SparseTokensField.SPARSE
 
 public class SparsePostingsConsumerTests extends AbstractSparseTestBase {
 
+    private static final String TEST_SPARSE_FIELD_NAME = "sparse_field";
+
     @Mock
     private FieldsConsumer mockDelegate;
 
@@ -121,7 +123,8 @@ public class SparsePostingsConsumerTests extends AbstractSparseTestBase {
      * Test constructor with specific version
      */
     public void test_constructor_withSpecificVersion() throws IOException {
-        SparsePostingsConsumer consumer = new SparsePostingsConsumer(mockDelegate, mockWriteState, 1);
+        int version = 1;
+        SparsePostingsConsumer consumer = new SparsePostingsConsumer(mockDelegate, mockWriteState, version);
         assertNotNull("Consumer should be created", consumer);
     }
 
@@ -173,7 +176,7 @@ public class SparsePostingsConsumerTests extends AbstractSparseTestBase {
     }
 
     /**
-     * Test write method with sparse fields and empty terms
+     * Test write method with sparse fields and terms
      */
     @SneakyThrows
     public void test_write_withSparseFields_andTerms() {
@@ -190,12 +193,12 @@ public class SparsePostingsConsumerTests extends AbstractSparseTestBase {
         when(mockFieldInfos.fieldInfo(anyString())).thenReturn(mockFieldInfo);
 
         // Setup fields mock
-        List<String> fieldNames = List.of("sparse_field");
+        List<String> fieldNames = List.of(TEST_SPARSE_FIELD_NAME);
         when(mockFields.iterator()).thenReturn(fieldNames.iterator());
 
         // Setup terms mock
         Terms mockedTerms = mock(Terms.class);
-        when(mockFields.terms("sparse_field")).thenReturn(mockedTerms);
+        when(mockFields.terms(TEST_SPARSE_FIELD_NAME)).thenReturn(mockedTerms);
         TermsEnum mockedTermsEnum = mock(TermsEnum.class);
         when(mockedTerms.iterator()).thenReturn(mockedTermsEnum);
         BytesRef term1 = new BytesRef("term1");
@@ -210,7 +213,7 @@ public class SparsePostingsConsumerTests extends AbstractSparseTestBase {
     }
 
     /**
-     * Test write method with sparse fields and terms
+     * Test write method with sparse fields and empty terms
      */
     @SneakyThrows
     public void test_write_withSparseFields_andEmptyTerms() {
@@ -227,9 +230,9 @@ public class SparsePostingsConsumerTests extends AbstractSparseTestBase {
         when(mockFieldInfos.fieldInfo(anyString())).thenReturn(mockFieldInfo);
 
         // Setup fields mock
-        List<String> fieldNames = List.of("sparse_field");
+        List<String> fieldNames = List.of(TEST_SPARSE_FIELD_NAME);
         when(mockFields.iterator()).thenReturn(fieldNames.iterator());
-        when(mockFields.terms("sparse_field")).thenReturn(null);
+        when(mockFields.terms(TEST_SPARSE_FIELD_NAME)).thenReturn(null);
 
         // Call write
         sparsePostingsConsumer.write(mockFields, mockNormsProducer);

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsEnumTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsEnumTests.java
@@ -132,6 +132,7 @@ public class SparsePostingsEnumTests extends AbstractSparseTestBase {
 
         sparsePostingsEnum = new SparsePostingsEnum(mockClusters, mockCacheKey);
 
+        // -1 is the default value when current doc weight is null
         assertEquals(-1, sparsePostingsEnum.docID());
         verify(mockDocWeightIterator, never()).docID();
     }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsEnumTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsEnumTests.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.common.DocWeightIterator;
+import org.opensearch.neuralsearch.sparse.common.IteratorWrapper;
+import org.opensearch.neuralsearch.sparse.data.DocumentCluster;
+import org.opensearch.neuralsearch.sparse.data.PostingClusters;
+import org.opensearch.neuralsearch.sparse.quantization.ByteQuantizer;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+public class SparsePostingsEnumTests extends AbstractSparseTestBase {
+
+    @Mock
+    private CacheKey mockCacheKey;
+    @Mock
+    private PostingClusters mockClusters;
+    @Mock
+    private DocumentCluster mockDocumentCluster;
+    @Mock
+    private DocWeightIterator mockDocWeightIterator;
+    @Mock
+    private IteratorWrapper<DocumentCluster> mockClusterIterator;
+
+    private SparsePostingsEnum sparsePostingsEnum;
+
+    @Before
+    @Override
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        when(mockClusters.iterator()).thenReturn(mockClusterIterator);
+        when(mockClusterIterator.next()).thenReturn(mockDocumentCluster);
+        when(mockClusterIterator.hasNext()).thenReturn(true);
+        when(mockDocumentCluster.getDisi()).thenReturn(mockDocWeightIterator);
+        when(mockDocWeightIterator.docID()).thenReturn(0);
+
+        sparsePostingsEnum = new SparsePostingsEnum(mockClusters, mockCacheKey);
+    }
+
+    @SneakyThrows
+    public void testConstructor() {
+        SparsePostingsEnum sparsePostingsEnum = new SparsePostingsEnum(mockClusters, mockCacheKey);
+
+        assertEquals(mockClusters, sparsePostingsEnum.getClusters());
+        assertEquals(mockCacheKey, sparsePostingsEnum.getCacheKey());
+    }
+
+    public void testClusterIterator() {
+        // reset mockClusters because setUp calls it
+        reset(mockClusters);
+        when(mockClusters.iterator()).thenReturn(mockClusterIterator);
+
+        IteratorWrapper<DocumentCluster> result = sparsePostingsEnum.clusterIterator();
+
+        verify(mockClusters, times(1)).iterator();
+        assertEquals(mockClusterIterator, result);
+    }
+
+    public void testSize() {
+        int expectedSize = 100;
+        when(mockClusters.getSize()).thenReturn(expectedSize);
+
+        assertEquals(expectedSize, sparsePostingsEnum.size());
+        verify(mockClusters, times(1)).getSize();
+    }
+
+    public void testFreq() throws IOException {
+        byte expectedWeight = 100;
+        when(mockDocWeightIterator.weight()).thenReturn(expectedWeight);
+
+        int result = sparsePostingsEnum.freq();
+
+        verify(mockDocWeightIterator, times(1)).weight();
+        assertEquals(ByteQuantizer.getUnsignedByte(expectedWeight), result);
+    }
+
+    public void testNextPosition() {
+        Exception exception = expectThrows(UnsupportedOperationException.class, () -> sparsePostingsEnum.nextPosition());
+        assertNull(exception.getMessage());
+    }
+
+    public void testStartOffset() {
+        Exception exception = expectThrows(UnsupportedOperationException.class, () -> sparsePostingsEnum.startOffset());
+        assertNull(exception.getMessage());
+
+    }
+
+    public void testEndOffset() {
+        Exception exception = expectThrows(UnsupportedOperationException.class, () -> sparsePostingsEnum.endOffset());
+        assertNull(exception.getMessage());
+    }
+
+    public void testGetPayload() {
+        Exception exception = expectThrows(UnsupportedOperationException.class, () -> sparsePostingsEnum.getPayload());
+        assertNull(exception.getMessage());
+    }
+
+    public void testDocID() {
+        int expectedDocID = 10;
+        when(mockDocWeightIterator.docID()).thenReturn(expectedDocID);
+
+        assertEquals(expectedDocID, sparsePostingsEnum.docID());
+        verify(mockDocWeightIterator, times(1)).docID();
+    }
+
+    @SneakyThrows
+    public void testDocID_currentDocWeightNull() {
+        when(mockClusters.iterator()).thenReturn(mockClusterIterator);
+        when(mockClusterIterator.next()).thenReturn(mockDocumentCluster);
+        when(mockClusterIterator.hasNext()).thenReturn(true);
+        when(mockDocumentCluster.getDisi()).thenReturn(null);
+
+        sparsePostingsEnum = new SparsePostingsEnum(mockClusters, mockCacheKey);
+
+        assertEquals(-1, sparsePostingsEnum.docID());
+        verify(mockDocWeightIterator, never()).docID();
+    }
+
+    public void testNextDoc_noMoreDocs() throws IOException {
+        when(mockDocWeightIterator.nextDoc()).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+        when(mockClusterIterator.hasNext()).thenReturn(false);
+
+        int result = sparsePostingsEnum.nextDoc();
+
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, result);
+        verify(mockDocWeightIterator).nextDoc();
+        verify(mockClusterIterator).hasNext();
+    }
+
+    public void testNextDoc_currentCluster() throws IOException {
+        int expectedDocId = 10;
+        when(mockDocWeightIterator.nextDoc()).thenReturn(expectedDocId);
+
+        int result = sparsePostingsEnum.nextDoc();
+
+        assertEquals(expectedDocId, result);
+        verify(mockDocWeightIterator).nextDoc();
+    }
+
+    public void testNextDoc_nextCluster() throws IOException {
+        // reset mockDocWeightIterator and mockClusterIterator because setUp calls it
+        reset(mockDocWeightIterator);
+        reset(mockClusterIterator);
+
+        when(mockDocWeightIterator.nextDoc()).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+        when(mockClusterIterator.hasNext()).thenReturn(true);
+
+        // configure the next cluster
+        int expectedDocId = 10;
+        DocWeightIterator mockSecondDocWeightIterator = mock(DocWeightIterator.class);
+        DocumentCluster mockSecondCluster = mock(DocumentCluster.class);
+        when(mockSecondCluster.getDisi()).thenReturn(mockSecondDocWeightIterator);
+        when(mockSecondDocWeightIterator.nextDoc()).thenReturn(expectedDocId);
+
+        when(mockClusterIterator.next()).thenReturn(mockSecondCluster);
+
+        int result = sparsePostingsEnum.nextDoc();
+
+        assertEquals(expectedDocId, result);
+        verify(mockDocWeightIterator, times(1)).nextDoc();
+        verify(mockClusterIterator, times(1)).next();
+        verify(mockSecondDocWeightIterator, times(1)).nextDoc();
+    }
+
+    public void testAdvance() {
+        Exception exception = expectThrows(UnsupportedOperationException.class, () -> sparsePostingsEnum.advance(5));
+        assertNull(exception.getMessage());
+    }
+
+    public void testCost() {
+        assertEquals(0, sparsePostingsEnum.cost());
+    }
+}


### PR DESCRIPTION
### Description

This PR implements UT for SparsePostingsEnum and SparsePostingsConsumer. Both classes achieve 100% code coverage.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
