### PR TITLE
UT: increase code coverage for Codec

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsFormatTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsFormatTests.java
@@ -6,6 +6,7 @@ package org.opensearch.neuralsearch.sparse.codec;
 
 import lombok.SneakyThrows;
 import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
@@ -68,6 +69,32 @@ public class SparsePostingsFormatTests extends AbstractSparseTestBase {
 
         // Execute & Verify
         IOException exception = expectThrows(IOException.class, () -> { this.sparsePostingsFormat.fieldsConsumer(mockWriteState); });
+        assertEquals("Test exception", exception.getMessage());
+    }
+
+    @SneakyThrows
+    public void testFieldsProducer() {
+        // Setup
+        FieldsProducer mockDelegateProducer = mock(FieldsProducer.class);
+        when(mockDelegate.fieldsProducer(mockReadState)).thenReturn(mockDelegateProducer);
+
+        // Execute
+        FieldsProducer result = this.sparsePostingsFormat.fieldsProducer(mockReadState);
+
+        // Verify
+        assertNotNull(result);
+        assertTrue(result instanceof SparsePostingsProducer);
+        verify(mockDelegate).fieldsProducer(mockReadState);
+    }
+
+    @SneakyThrows
+    public void testFieldsProducerIOException() {
+        // Setup
+        IOException expectedException = new IOException("Test exception");
+        when(mockDelegate.fieldsProducer(mockReadState)).thenThrow(expectedException);
+
+        // Execute & Verify
+        IOException exception = expectThrows(IOException.class, () -> { this.sparsePostingsFormat.fieldsProducer(mockReadState); });
         assertEquals("Test exception", exception.getMessage());
     }
 }


### PR DESCRIPTION
### Description
This PR increase code coverage for SparsePostingsFormat and SparseDocValuesConsumer. It's now 100% and 98% coverage.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
