### PR TITLE
Optimize: Use smaller synchronize in lucene reader

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/cache/CacheGatedForwardIndexReader.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/cache/CacheGatedForwardIndexReader.java
@@ -74,9 +74,7 @@ public class CacheGatedForwardIndexReader implements SparseVectorReader {
             return vector;
         }
 
-        synchronized (luceneReader) {
-            vector = luceneReader.read(docId);
-        }
+        vector = luceneReader.read(docId);
         if (vector != null) {
             cacheWriter.insert(docId, vector);
         }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/cache/CacheGatedPostingsReader.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/cache/CacheGatedPostingsReader.java
@@ -40,9 +40,7 @@ public class CacheGatedPostingsReader implements ClusteredPostingReader {
             return clusters;
         }
         // if cluster does not exist in cache, read from lucene and populate it to cache
-        synchronized (luceneReader) {
-            clusters = luceneReader.read(fieldName, term);
-        }
+        clusters = luceneReader.read(fieldName, term);
 
         if (clusters != null) {
             cacheWriter.insert(term, clusters.getClusters());

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesPassThrough.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesPassThrough.java
@@ -53,10 +53,13 @@ public class SparseBinaryDocValuesPassThrough extends BinaryDocValues implements
 
     @Override
     public SparseVector read(int docId) throws IOException {
-        if (!advanceExact(docId)) {
-            return null;
+        BytesRef bytesRef;
+        synchronized (this) {
+            if (!advanceExact(docId)) {
+                return null;
+            }
+            bytesRef = binaryValue();
         }
-        BytesRef bytesRef = binaryValue();
         if (bytesRef == null) {
             return null;
         }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneReader.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneReader.java
@@ -112,7 +112,7 @@ public class SparseTermsLuceneReader extends FieldsProducer {
         return fieldToTerms.keySet().iterator();
     }
 
-    private List<DocumentCluster> readClusters(long offset) throws IOException {
+    private synchronized List<DocumentCluster> readClusters(long offset) throws IOException {
         postingIn.seek(offset);
         long clusterSize = postingIn.readVLong();
         List<DocumentCluster> clusters = new ArrayList<>((int) clusterSize);
@@ -159,7 +159,7 @@ public class SparseTermsLuceneReader extends FieldsProducer {
         }
         long offset = termsMapping.get(term);
         List<DocumentCluster> clusters = readClusters(offset);
-        if (clusters == null || clusters.isEmpty()) {
+        if (clusters.isEmpty()) {
             return null;
         }
         return new PostingClusters(clusters);
@@ -177,6 +177,7 @@ public class SparseTermsLuceneReader extends FieldsProducer {
 
     @Override
     public void checkIntegrity() throws IOException {
-
+        CodecUtil.checksumEntireFile(termsIn);
+        CodecUtil.checksumEntireFile(postingIn);
     }
 }


### PR DESCRIPTION
### Description
This PR use smaller synchronized block for lucene reader

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
