### PR TITLE
Fix: Adjust IT according to memory stats change

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/rest/RestNeuralStatsAction.java
+++ b/src/main/java/org/opensearch/neuralsearch/rest/RestNeuralStatsAction.java
@@ -238,7 +238,7 @@ public class RestNeuralStatsAction extends BaseRestHandler {
 
         String[] stats = optionalStats.get();
         Set<String> invalidStatNames = new HashSet<>();
-        boolean includeEventsAndMetrics = neuralStatsInput.includeEventsAndMetrics();
+        boolean includeEvents = neuralStatsInput.isIncludeEvents();
         boolean includeInfo = neuralStatsInput.isIncludeInfo();
         boolean includeMetrics = neuralStatsInput.isIncludeMetrics();
 
@@ -254,17 +254,10 @@ public class RestNeuralStatsAction extends BaseRestHandler {
                 if (infoStatName.version().onOrBefore(minClusterVersion)) {
                     neuralStatsInput.getInfoStatNames().add(InfoStatName.from(normalizedStat));
                 }
-            } else if (includeEventsAndMetrics) {
-                if (EventStatName.isValidName(normalizedStat)) {
-                    EventStatName eventStatName = EventStatName.from(normalizedStat);
-                    if (eventStatName.version().onOrBefore(minClusterVersion)) {
-                        neuralStatsInput.getEventStatNames().add(EventStatName.from(normalizedStat));
-                    }
-                } else if (MetricStatName.isValidName(normalizedStat)) {
-                    MetricStatName metricStatName = MetricStatName.from(normalizedStat);
-                    if (metricStatName.version().onOrBefore(minClusterVersion)) {
-                        neuralStatsInput.getMetricStatNames().add(MetricStatName.from(normalizedStat));
-                    }
+            } else if (includeEvents && EventStatName.isValidName(normalizedStat)) {
+                EventStatName eventStatName = EventStatName.from(normalizedStat);
+                if (eventStatName.version().onOrBefore(minClusterVersion)) {
+                    neuralStatsInput.getEventStatNames().add(EventStatName.from(normalizedStat));
                 }
             } else if (includeMetrics && MetricStatName.isValidName(normalizedStat)) {
                 MetricStatName metricStatName = MetricStatName.from(normalizedStat);
@@ -288,9 +281,8 @@ public class RestNeuralStatsAction extends BaseRestHandler {
             if (neuralStatsInput.isIncludeInfo()) {
                 neuralStatsInput.getInfoStatNames().addAll(EnumSet.allOf(InfoStatName.class));
             }
-            if (neuralStatsInput.includeEventsAndMetrics()) {
+            if (neuralStatsInput.isIncludeEvents()) {
                 neuralStatsInput.getEventStatNames().addAll(EnumSet.allOf(EventStatName.class));
-                neuralStatsInput.getMetricStatNames().addAll(EnumSet.allOf(MetricStatName.class));
             }
             if (neuralStatsInput.isIncludeMetrics()) {
                 neuralStatsInput.getMetricStatNames().addAll(EnumSet.allOf(MetricStatName.class));
@@ -305,20 +297,13 @@ public class RestNeuralStatsAction extends BaseRestHandler {
                             .collect(Collectors.toCollection(() -> EnumSet.noneOf(InfoStatName.class)))
                     );
             }
-            if (neuralStatsInput.includeEventsAndMetrics()) {
+            if (neuralStatsInput.isIncludeEvents()) {
                 neuralStatsInput.getEventStatNames()
                     .addAll(
                         EnumSet.allOf(EventStatName.class)
                             .stream()
                             .filter(statName -> statName.version().onOrBefore(minVersion))
                             .collect(Collectors.toCollection(() -> EnumSet.noneOf(EventStatName.class)))
-                    );
-                neuralStatsInput.getMetricStatNames()
-                    .addAll(
-                        EnumSet.allOf(MetricStatName.class)
-                            .stream()
-                            .filter(statName -> statName.version().onOrBefore(minVersion))
-                            .collect(Collectors.toCollection(() -> EnumSet.noneOf(MetricStatName.class)))
                     );
             }
             if (neuralStatsInput.isIncludeMetrics()) {
@@ -345,5 +330,4 @@ public class RestNeuralStatsAction extends BaseRestHandler {
     private boolean isValidStatName(String statName) {
         return InfoStatName.isValidName(statName) || EventStatName.isValidName(statName) || MetricStatName.isValidName(statName);
     }
-
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldMapper.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldMapper.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.APPROXIMATE_THRESHOLD_FIELD;
-
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.CLUSTER_RATIO_FIELD;
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.N_POSTINGS_FIELD;
 import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SEISMIC;

--- a/src/main/java/org/opensearch/neuralsearch/stats/NeuralStatsInput.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/NeuralStatsInput.java
@@ -234,7 +234,7 @@ public class NeuralStatsInput implements ToXContentObject, Writeable {
      * If we exclude both individual and all nodes, then there is no need to fetch any specific stats from nodes
      * @return whether we need to fetch event stats
      */
-    public boolean includeEventsAndMetrics() {
+    public boolean isIncludeEvents() {
         return this.isIncludeAllNodes() || this.isIncludeIndividualNodes();
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/util/NeuralSearchClusterUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/NeuralSearchClusterUtil.java
@@ -6,7 +6,6 @@ package org.opensearch.neuralsearch.util;
 
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.Getter;
 import org.opensearch.Version;
 import org.opensearch.action.IndicesRequest;
 import org.opensearch.cluster.metadata.IndexMetadata;

--- a/src/test/java/org/opensearch/neuralsearch/sparse/AbstractSparseTestBase.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/AbstractSparseTestBase.java
@@ -15,7 +15,6 @@ import org.opensearch.neuralsearch.sparse.data.DocWeight;
 import org.opensearch.neuralsearch.sparse.data.DocumentCluster;
 import org.opensearch.neuralsearch.sparse.data.PostingClusters;
 import org.opensearch.neuralsearch.sparse.data.SparseVector;
-
 import org.opensearch.neuralsearch.sparse.cache.CircuitBreakerManager;
 import org.opensearch.core.common.breaker.CircuitBreaker;
 import org.apache.lucene.index.LeafReader;

--- a/src/test/java/org/opensearch/neuralsearch/sparse/NeuralSparseCacheOperationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/NeuralSparseCacheOperationIT.java
@@ -16,12 +16,11 @@ import org.opensearch.neuralsearch.query.NeuralSparseQueryBuilder;
 import org.opensearch.neuralsearch.settings.NeuralSearchSettings;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
+import static org.opensearch.neuralsearch.util.TestUtils.DELTA_FOR_SCORE_ASSERTION;
 import static org.opensearch.neuralsearch.util.TestUtils.getTotalHits;
 
 /**
@@ -72,8 +71,8 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         // First clear cache before warm up
         Request clearCacheRequest = new Request("POST", "/_plugins/_neural/clear_cache/" + TEST_INDEX_NAME);
         Response clearCacheResponse = client().performRequest(clearCacheRequest);
-        long[] originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long originalSparseMemoryUsageSum = Arrays.stream(originalSparseMemoryUsageStats).sum();
+        List<Double> originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        double originalSparseMemoryUsageSum = originalSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
 
         // Execute warm up cache request
         Request warmUpRequest = new Request("POST", "/_plugins/_neural/warmup/" + TEST_INDEX_NAME);
@@ -92,20 +91,12 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         assertTrue(responseMap.containsKey("_shards"));
 
         // Verify memory usage increased after warm up
-        long[] afterWarmUpSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long afterWarmUpSparseMemoryUsageSum = Arrays.stream(afterWarmUpSparseMemoryUsageStats).sum();
+        List<Double> afterWarmUpSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        double afterWarmUpSparseMemoryUsageSum = afterWarmUpSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
         assertTrue("Memory usage should increase after warm up", afterWarmUpSparseMemoryUsageSum > originalSparseMemoryUsageSum);
-        for (int i = 0; i < originalSparseMemoryUsageStats.length; i++) {
-            assertTrue(
-                String.format(
-                    Locale.ROOT,
-                    "Memory usage for node %d should increase after warm up (before: %d, after: %d)",
-                    i,
-                    originalSparseMemoryUsageStats[i],
-                    afterWarmUpSparseMemoryUsageStats[i]
-                ),
-                afterWarmUpSparseMemoryUsageStats[i] > originalSparseMemoryUsageStats[i]
-            );
+        assertEquals(originalSparseMemoryUsageStats.size(), afterWarmUpSparseMemoryUsageStats.size());
+        for (int i = 0; i < originalSparseMemoryUsageStats.size(); i++) {
+            assertTrue(afterWarmUpSparseMemoryUsageStats.get(i) > originalSparseMemoryUsageStats.get(i));
         }
     }
 
@@ -114,8 +105,8 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
      */
     @SneakyThrows
     public void testClearCache() {
-        long[] originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long originalSparseMemoryUsageSum = Arrays.stream(originalSparseMemoryUsageStats).sum();
+        List<Double> originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        double originalSparseMemoryUsageSum = originalSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
 
         // Execute clear cache request
         Request clearCacheRequest = new Request("POST", "/_plugins/_neural/clear_cache/" + TEST_INDEX_NAME);
@@ -133,20 +124,12 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         assertTrue(responseMap.containsKey("_shards"));
 
         // Verify memory usage decreased after clear cache
-        long[] afterClearCacheSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long afterClearCacheSparseMemoryUsageSum = Arrays.stream(afterClearCacheSparseMemoryUsageStats).sum();
+        List<Double> afterClearCacheSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        double afterClearCacheSparseMemoryUsageSum = afterClearCacheSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
         assertTrue("Memory usage should decrease after clear cache", afterClearCacheSparseMemoryUsageSum < originalSparseMemoryUsageSum);
-        for (int i = 0; i < originalSparseMemoryUsageStats.length; i++) {
-            assertTrue(
-                String.format(
-                    Locale.ROOT,
-                    "Memory usage for node %d should decrease after warm up (before: %d, after: %d)",
-                    i,
-                    originalSparseMemoryUsageStats[i],
-                    afterClearCacheSparseMemoryUsageStats[i]
-                ),
-                afterClearCacheSparseMemoryUsageStats[i] < originalSparseMemoryUsageStats[i]
-            );
+        assertEquals(originalSparseMemoryUsageStats.size(), afterClearCacheSparseMemoryUsageStats.size());
+        for (int i = 0; i < originalSparseMemoryUsageStats.size(); i++) {
+            assertTrue(afterClearCacheSparseMemoryUsageStats.get(i) < originalSparseMemoryUsageStats.get(i));
         }
     }
 
@@ -163,8 +146,8 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         // First clear cache before warm up
         Request clearCacheRequest = new Request("POST", "/_plugins/_neural/clear_cache/" + TEST_INDEX_NAME);
         Response clearCacheResponse = client().performRequest(clearCacheRequest);
-        long[] originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long originalSparseMemoryUsageSum = Arrays.stream(originalSparseMemoryUsageStats).sum();
+        List<Double> originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        double originalSparseMemoryUsageSum = originalSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
 
         // Execute warm up cache request
         Request warmUpRequest = new Request("POST", "/_plugins/_neural/warmup/" + TEST_INDEX_NAME);
@@ -183,20 +166,12 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         assertTrue(responseMap.containsKey("_shards"));
 
         // Verify memory usage increased after warm up
-        long[] afterWarmUpSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long afterWarmUpSparseMemoryUsageSum = Arrays.stream(afterWarmUpSparseMemoryUsageStats).sum();
+        List<Double> afterWarmUpSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        double afterWarmUpSparseMemoryUsageSum = afterWarmUpSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
         assertTrue("Memory usage should increase after warm up", afterWarmUpSparseMemoryUsageSum > originalSparseMemoryUsageSum);
-        for (int i = 0; i < originalSparseMemoryUsageStats.length; i++) {
-            assertTrue(
-                String.format(
-                    Locale.ROOT,
-                    "Memory usage for node %d should increase after warm up (before: %d, after: %d)",
-                    i,
-                    originalSparseMemoryUsageStats[i],
-                    afterWarmUpSparseMemoryUsageStats[i]
-                ),
-                afterWarmUpSparseMemoryUsageStats[i] > originalSparseMemoryUsageStats[i]
-            );
+        assertEquals(originalSparseMemoryUsageStats.size(), afterWarmUpSparseMemoryUsageStats.size());
+        for (int i = 0; i < originalSparseMemoryUsageStats.size(); i++) {
+            assertTrue(afterWarmUpSparseMemoryUsageStats.get(i) > originalSparseMemoryUsageStats.get(i));
         }
     }
 
@@ -209,8 +184,8 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         client().performRequest(request);
         // Create Sparse Index
         prepareMultiShardReplicasIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, TEST_TEXT_FIELD_NAME);
-        long[] originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long originalSparseMemoryUsageSum = Arrays.stream(originalSparseMemoryUsageStats).sum();
+        List<Double> originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        double originalSparseMemoryUsageSum = originalSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
 
         // Execute clear cache request
         Request clearCacheRequest = new Request("POST", "/_plugins/_neural/clear_cache/" + TEST_INDEX_NAME);
@@ -228,20 +203,12 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         assertTrue(responseMap.containsKey("_shards"));
 
         // Verify memory usage decreased after clear cache
-        long[] afterClearCacheSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long afterClearCacheSparseMemoryUsageSum = Arrays.stream(afterClearCacheSparseMemoryUsageStats).sum();
+        List<Double> afterClearCacheSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        double afterClearCacheSparseMemoryUsageSum = afterClearCacheSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
         assertTrue("Memory usage should decrease after clear cache", afterClearCacheSparseMemoryUsageSum < originalSparseMemoryUsageSum);
-        for (int i = 0; i < originalSparseMemoryUsageStats.length; i++) {
-            assertTrue(
-                String.format(
-                    Locale.ROOT,
-                    "Memory usage for node %d should decrease after warm up (before: %d, after: %d)",
-                    i,
-                    originalSparseMemoryUsageStats[i],
-                    afterClearCacheSparseMemoryUsageStats[i]
-                ),
-                afterClearCacheSparseMemoryUsageStats[i] < originalSparseMemoryUsageStats[i]
-            );
+        assertEquals(originalSparseMemoryUsageStats.size(), afterClearCacheSparseMemoryUsageStats.size());
+        for (int i = 0; i < originalSparseMemoryUsageStats.size(); i++) {
+            assertTrue(afterClearCacheSparseMemoryUsageStats.get(i) < originalSparseMemoryUsageStats.get(i));
         }
     }
 
@@ -258,8 +225,8 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         // First clear cache before warm up
         Request clearCacheRequest = new Request("POST", "/_plugins/_neural/clear_cache/" + TEST_INDEX_NAME);
         Response clearCacheResponse = client().performRequest(clearCacheRequest);
-        long[] originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long originalSparseMemoryUsageSum = Arrays.stream(originalSparseMemoryUsageStats).sum();
+        List<Double> originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        double originalSparseMemoryUsageSum = originalSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
 
         // Execute warm up cache request
         Request warmUpRequest = new Request("POST", "/_plugins/_neural/warmup/" + TEST_INDEX_NAME);
@@ -278,20 +245,12 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         assertTrue(responseMap.containsKey("_shards"));
 
         // Verify memory usage increased after warm up
-        long[] afterWarmUpSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long afterWarmUpSparseMemoryUsageSum = Arrays.stream(afterWarmUpSparseMemoryUsageStats).sum();
+        List<Double> afterWarmUpSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        double afterWarmUpSparseMemoryUsageSum = afterWarmUpSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
         assertTrue("Memory usage should increase after warm up", afterWarmUpSparseMemoryUsageSum > originalSparseMemoryUsageSum);
-        for (int i = 0; i < originalSparseMemoryUsageStats.length; i++) {
-            assertTrue(
-                String.format(
-                    Locale.ROOT,
-                    "Memory usage for node %d should increase after warm up (before: %d, after: %d)",
-                    i,
-                    originalSparseMemoryUsageStats[i],
-                    afterWarmUpSparseMemoryUsageStats[i]
-                ),
-                afterWarmUpSparseMemoryUsageStats[i] > originalSparseMemoryUsageStats[i]
-            );
+        assertEquals(originalSparseMemoryUsageStats.size(), afterWarmUpSparseMemoryUsageStats.size());
+        for (int i = 0; i < originalSparseMemoryUsageStats.size(); i++) {
+            assertTrue(afterWarmUpSparseMemoryUsageStats.get(i) > originalSparseMemoryUsageStats.get(i));
         }
     }
 
@@ -304,8 +263,8 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         client().performRequest(request);
         // Create Sparse Index
         prepareMixSeismicRankFeaturesIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, TEST_TEXT_FIELD_NAME);
-        long[] originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long originalSparseMemoryUsageSum = Arrays.stream(originalSparseMemoryUsageStats).sum();
+        List<Double> originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        double originalSparseMemoryUsageSum = originalSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
 
         // Execute clear cache request
         Request clearCacheRequest = new Request("POST", "/_plugins/_neural/clear_cache/" + TEST_INDEX_NAME);
@@ -323,20 +282,12 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         assertTrue(responseMap.containsKey("_shards"));
 
         // Verify memory usage decreased after clear cache
-        long[] afterClearCacheSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long afterClearCacheSparseMemoryUsageSum = Arrays.stream(afterClearCacheSparseMemoryUsageStats).sum();
+        List<Double> afterClearCacheSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        double afterClearCacheSparseMemoryUsageSum = afterClearCacheSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
         assertTrue("Memory usage should decrease after clear cache", afterClearCacheSparseMemoryUsageSum < originalSparseMemoryUsageSum);
-        for (int i = 0; i < originalSparseMemoryUsageStats.length; i++) {
-            assertTrue(
-                String.format(
-                    Locale.ROOT,
-                    "Memory usage for node %d should decrease after warm up (before: %d, after: %d)",
-                    i,
-                    originalSparseMemoryUsageStats[i],
-                    afterClearCacheSparseMemoryUsageStats[i]
-                ),
-                afterClearCacheSparseMemoryUsageStats[i] < originalSparseMemoryUsageStats[i]
-            );
+        assertEquals(originalSparseMemoryUsageStats.size(), afterClearCacheSparseMemoryUsageStats.size());
+        for (int i = 0; i < originalSparseMemoryUsageStats.size(); i++) {
+            assertTrue(afterClearCacheSparseMemoryUsageStats.get(i) < originalSparseMemoryUsageStats.get(i));
         }
     }
 
@@ -353,8 +304,8 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         // First clear cache before warm up
         Request clearCacheRequest = new Request("POST", "/_plugins/_neural/clear_cache/" + TEST_INDEX_NAME);
         Response clearCacheResponse = client().performRequest(clearCacheRequest);
-        long[] originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long originalSparseMemoryUsageSum = Arrays.stream(originalSparseMemoryUsageStats).sum();
+        List<Double> originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        double originalSparseMemoryUsageSum = originalSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
 
         // Execute warm up cache request
         Request warmUpRequest = new Request("POST", "/_plugins/_neural/warmup/" + TEST_INDEX_NAME);
@@ -373,21 +324,17 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         assertTrue(responseMap.containsKey("_shards"));
 
         // Verify memory usage not changed after warm up
-        long[] afterWarmUpSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long afterWarmUpSparseMemoryUsageSum = Arrays.stream(afterWarmUpSparseMemoryUsageStats).sum();
-        assertEquals("Memory usage should not change after warm up", afterWarmUpSparseMemoryUsageSum, originalSparseMemoryUsageSum);
-        for (int i = 0; i < originalSparseMemoryUsageStats.length; i++) {
-            assertEquals(
-                String.format(
-                    Locale.ROOT,
-                    "Memory usage for node %d should not change after warm up (before: %d, after: %d)",
-                    i,
-                    originalSparseMemoryUsageStats[i],
-                    originalSparseMemoryUsageStats[i]
-                ),
-                originalSparseMemoryUsageStats[i],
-                originalSparseMemoryUsageStats[i]
-            );
+        List<Double> afterWarmUpSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        double afterWarmUpSparseMemoryUsageSum = afterWarmUpSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
+        assertEquals(
+            "Memory usage should not change after warm up",
+            afterWarmUpSparseMemoryUsageSum,
+            originalSparseMemoryUsageSum,
+            DELTA_FOR_SCORE_ASSERTION
+        );
+        assertEquals(originalSparseMemoryUsageStats.size(), afterWarmUpSparseMemoryUsageStats.size());
+        for (int i = 0; i < originalSparseMemoryUsageStats.size(); i++) {
+            assertEquals(originalSparseMemoryUsageStats.get(i), afterWarmUpSparseMemoryUsageStats.get(i));
         }
     }
 
@@ -400,8 +347,8 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         client().performRequest(request);
         // Create Sparse Index
         prepareOnlyRankFeaturesIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, TEST_TEXT_FIELD_NAME);
-        long[] originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long originalSparseMemoryUsageSum = Arrays.stream(originalSparseMemoryUsageStats).sum();
+        List<Double> originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        double originalSparseMemoryUsageSum = originalSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
 
         // Execute clear cache request
         Request clearCacheRequest = new Request("POST", "/_plugins/_neural/clear_cache/" + TEST_INDEX_NAME);
@@ -419,21 +366,17 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         assertTrue(responseMap.containsKey("_shards"));
 
         // Verify memory usage not changed after clear cache
-        long[] afterClearCacheSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long afterClearCacheSparseMemoryUsageSum = Arrays.stream(afterClearCacheSparseMemoryUsageStats).sum();
-        assertEquals("Memory usage should not change after clear cache", afterClearCacheSparseMemoryUsageSum, originalSparseMemoryUsageSum);
-        for (int i = 0; i < originalSparseMemoryUsageStats.length; i++) {
-            assertEquals(
-                String.format(
-                    Locale.ROOT,
-                    "Memory usage for node %d should not change after clear cache (before: %d, after: %d)",
-                    i,
-                    originalSparseMemoryUsageStats[i],
-                    afterClearCacheSparseMemoryUsageStats[i]
-                ),
-                afterClearCacheSparseMemoryUsageStats[i],
-                originalSparseMemoryUsageStats[i]
-            );
+        List<Double> afterClearCacheSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        double afterClearCacheSparseMemoryUsageSum = afterClearCacheSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
+        assertEquals(
+            "Memory usage should not change after clear cache",
+            afterClearCacheSparseMemoryUsageSum,
+            originalSparseMemoryUsageSum,
+            DELTA_FOR_SCORE_ASSERTION
+        );
+        assertEquals(originalSparseMemoryUsageStats.size(), afterClearCacheSparseMemoryUsageStats.size());
+        for (int i = 0; i < originalSparseMemoryUsageStats.size(); i++) {
+            assertEquals(afterClearCacheSparseMemoryUsageStats.get(i), originalSparseMemoryUsageStats.get(i));
         }
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/sparse/NeuralSparseCacheOperationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/NeuralSparseCacheOperationIT.java
@@ -395,7 +395,7 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         Request warmUpRequest = new Request("POST", "/_plugins/_neural/warmup/" + nonSparseIndex);
         ResponseException exception = expectThrows(ResponseException.class, () -> client().performRequest(warmUpRequest));
 
-        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, RestStatus.fromCode(exception.getResponse().getStatusLine().getStatusCode()));
+        assertEquals(RestStatus.BAD_REQUEST, RestStatus.fromCode(exception.getResponse().getStatusLine().getStatusCode()));
         String responseBody = EntityUtils.toString(exception.getResponse().getEntity());
         assertTrue(responseBody.contains("don't support neural_sparse_warmup_action operation"));
     }
@@ -415,7 +415,7 @@ public class NeuralSparseCacheOperationIT extends SparseBaseIT {
         Request clearCacheRequest = new Request("POST", "/_plugins/_neural/clear_cache/" + nonSparseIndex);
         ResponseException exception = expectThrows(ResponseException.class, () -> client().performRequest(clearCacheRequest));
 
-        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, RestStatus.fromCode(exception.getResponse().getStatusLine().getStatusCode()));
+        assertEquals(RestStatus.BAD_REQUEST, RestStatus.fromCode(exception.getResponse().getStatusLine().getStatusCode()));
         String responseBody = EntityUtils.toString(exception.getResponse().getEntity());
         assertTrue(responseBody.contains("don't support neural_sparse_clear_cache_action operation"));
     }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseBaseIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseBaseIT.java
@@ -6,6 +6,7 @@ package org.opensearch.neuralsearch.sparse;
 
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.Before;
@@ -418,7 +419,7 @@ public abstract class SparseBaseIT extends BaseNeuralSearchIT {
     }
 
     @SneakyThrows
-    protected long[] getSparseMemoryUsageStatsAcrossNodes() {
+    protected List<Double> getSparseMemoryUsageStatsAcrossNodes() {
         Request request = new Request("GET", NeuralSearch.NEURAL_BASE_URI + "/stats/" + SPARSE_MEMORY_USAGE_METRIC_NAME);
 
         Response response = client().performRequest(request);
@@ -427,36 +428,12 @@ public abstract class SparseBaseIT extends BaseNeuralSearchIT {
         String responseBody = EntityUtils.toString(response.getEntity());
         List<Map<String, Object>> nodeStatsResponseList = parseNodeStatsResponse(responseBody);
 
-        List<Long> sparseMemoryUsageStats = new ArrayList<>();
+        List<Double> sparseMemoryUsageStats = new ArrayList<>();
         for (Map<String, Object> nodeStatsResponse : nodeStatsResponseList) {
             // we do not use breakers.neural_search.estimated_size_in_bytes due to precision limitation by memory stats
             String stringValue = getNestedValue(nodeStatsResponse, SPARSE_MEMORY_USAGE_METRIC_PATH).toString();
-            sparseMemoryUsageStats.add(parseFractionalSize(stringValue));
+            sparseMemoryUsageStats.add(NumberUtils.createDouble(stringValue));
         }
-        return sparseMemoryUsageStats.stream().mapToLong(Long::longValue).toArray();
-    }
-
-    protected static long parseFractionalSize(String value) {
-        value = value.trim().toLowerCase(Locale.ROOT);
-        double number;
-        long multiplier;
-
-        if (value.endsWith("kb")) {
-            number = Double.parseDouble(value.replace("kb", "").trim());
-            multiplier = 1024L;
-        } else if (value.endsWith("mb")) {
-            number = Double.parseDouble(value.replace("mb", "").trim());
-            multiplier = 1024L * 1024L;
-        } else if (value.endsWith("gb")) {
-            number = Double.parseDouble(value.replace("gb", "").trim());
-            multiplier = 1024L * 1024L * 1024L;
-        } else if (value.endsWith("b")) {
-            number = Double.parseDouble(value.replace("b", "").trim());
-            multiplier = 1L;
-        } else {
-            throw new IllegalArgumentException("Unknown size unit: " + value);
-        }
-
-        return Math.round(number * multiplier);
+        return sparseMemoryUsageStats;
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseCircuitBreakerIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseCircuitBreakerIT.java
@@ -96,7 +96,7 @@ public class SparseCircuitBreakerIT extends SparseBaseIT {
         ingestDocumentsAndForceMerge(indexName, textField, sparseField, docs);
 
         // Verify that without cache, the search results remain the same
-        return getTotalHits(search(TEST_INDEX_NAME, neuralSparseQueryBuilder, 10));
+        return getTotalHits(search(indexName, neuralSparseQueryBuilder, 10));
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseCircuitBreakerIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseCircuitBreakerIT.java
@@ -104,9 +104,8 @@ public class SparseCircuitBreakerIT extends SparseBaseIT {
         ingestDocumentsAndForceMerge(TEST_INDEX_NAME, TEST_TEXT_FIELD_NAME, TEST_SPARSE_FIELD_NAME, docs2);
 
         MatchAllQueryBuilder matchAllQueryBuilder = new MatchAllQueryBuilder();
-        Map<String, Object> expectedIngestedDocuments = search(TEST_INDEX_NAME, matchAllQueryBuilder, 200);
-
         Map<String, Object> expectedHits = getTotalHits(search(TEST_INDEX_NAME, neuralSparseQueryBuilder, 10));
+        Map<String, Object> expectedIngestedDocuments = getTotalHits(search(TEST_INDEX_NAME, matchAllQueryBuilder, 200));
 
         // Delete index, ingest half documents and enable cache eviction by setting limit to zero
         deleteIndex(TEST_INDEX_NAME);
@@ -116,7 +115,7 @@ public class SparseCircuitBreakerIT extends SparseBaseIT {
         ingestDocumentsAndForceMerge(TEST_INDEX_NAME, TEST_TEXT_FIELD_NAME, TEST_SPARSE_FIELD_NAME, docs2);
 
         Map<String, Object> hits = getTotalHits(search(TEST_INDEX_NAME, neuralSparseQueryBuilder, 10));
-        Map<String, Object> ingestedDocuments = search(TEST_INDEX_NAME, matchAllQueryBuilder, 200);
+        Map<String, Object> ingestedDocuments = getTotalHits(search(TEST_INDEX_NAME, matchAllQueryBuilder, 200));
 
         assertEquals(expectedHits, hits);
         assertEquals(expectedIngestedDocuments, ingestedDocuments);

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseCircuitBreakerIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseCircuitBreakerIT.java
@@ -6,6 +6,7 @@ package org.opensearch.neuralsearch.sparse;
 
 import lombok.SneakyThrows;
 import org.junit.After;
+import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.neuralsearch.query.NeuralSparseQueryBuilder;
 import org.opensearch.neuralsearch.settings.NeuralSearchSettings;
 
@@ -78,6 +79,47 @@ public class SparseCircuitBreakerIT extends SparseBaseIT {
         );
 
         assertEquals(expectedHits, hits);
+    }
+
+    /**
+     * By setting circuit breaker limit to be zero, the LRU cache eviction will be enabled.
+     * Given the same index, the Seismic query should return the same results with cache eviction
+     */
+    @SneakyThrows
+    public void testQueryWithLRUEviction() {
+        // Create index and perform ingestion
+        int docCount = 100;
+        List<Map<String, Float>> docs1 = prepareIngestDocuments(docCount);
+        List<Map<String, Float>> docs2 = prepareIngestDocuments(docCount);
+        NeuralSparseQueryBuilder neuralSparseQueryBuilder = getNeuralSparseQueryBuilder(
+            TEST_SPARSE_FIELD_NAME,
+            2,
+            1.0f,
+            10,
+            Map.of("1000", 0.1f, "2000", 0.2f)
+        );
+
+        createSparseIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, 100, 0.4f, 0.1f, 100);
+        ingestDocumentsAndForceMerge(TEST_INDEX_NAME, TEST_TEXT_FIELD_NAME, TEST_SPARSE_FIELD_NAME, docs1);
+        ingestDocumentsAndForceMerge(TEST_INDEX_NAME, TEST_TEXT_FIELD_NAME, TEST_SPARSE_FIELD_NAME, docs2);
+
+        MatchAllQueryBuilder matchAllQueryBuilder = new MatchAllQueryBuilder();
+        Map<String, Object> expectedIngestedDocuments = search(TEST_INDEX_NAME, matchAllQueryBuilder, 200);
+
+        Map<String, Object> expectedHits = getTotalHits(search(TEST_INDEX_NAME, neuralSparseQueryBuilder, 10));
+
+        // Delete index, ingest half documents and enable cache eviction by setting limit to zero
+        deleteIndex(TEST_INDEX_NAME);
+        createSparseIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, 100, 0.4f, 0.1f, 100);
+        ingestDocumentsAndForceMerge(TEST_INDEX_NAME, TEST_TEXT_FIELD_NAME, TEST_SPARSE_FIELD_NAME, docs1);
+        updateClusterSettings(NeuralSearchSettings.NEURAL_CIRCUIT_BREAKER_LIMIT.getKey(), "0%");
+        ingestDocumentsAndForceMerge(TEST_INDEX_NAME, TEST_TEXT_FIELD_NAME, TEST_SPARSE_FIELD_NAME, docs2);
+
+        Map<String, Object> hits = getTotalHits(search(TEST_INDEX_NAME, neuralSparseQueryBuilder, 10));
+        Map<String, Object> ingestedDocuments = search(TEST_INDEX_NAME, matchAllQueryBuilder, 200);
+
+        assertEquals(expectedHits, hits);
+        assertEquals(expectedIngestedDocuments, ingestedDocuments);
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseMemoryStatsIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseMemoryStatsIT.java
@@ -161,30 +161,8 @@ public class SparseMemoryStatsIT extends SparseBaseIT {
         long[] originalCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
         assertArrayEquals(originalSparseMemoryUsageStats, originalCircuitBreakerMemoryStats);
 
-        // Create Sparse Index
-        // int docCount = 100;
-        // createSparseIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, 100, 0.4f, 0.1f, docCount * 2);
-        //
-        // // Verify index exists
-        // assertTrue(indexExists(TEST_INDEX_NAME));
-        //
-        //
-        //
-        // // Ingest documents
-        // List<Map<String, Float>> docs = new ArrayList<>();
-        // for (int i = 0; i < docCount; ++i) {
-        // Map<String, Float> tokens = new HashMap<>();
-        // tokens.put("1000", randomFloat());
-        // tokens.put("2000", randomFloat());
-        // tokens.put("3000", randomFloat());
-        // tokens.put("4000", randomFloat());
-        // tokens.put("5000", randomFloat());
-        // docs.add(tokens);
-        // }
-        //
-        // ingestDocumentsAndForceMerge(TEST_INDEX_NAME, TEST_TEXT_FIELD_NAME, TEST_SPARSE_FIELD_NAME, docs);
-
         prepareOnlyRankFeaturesIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, TEST_TEXT_FIELD_NAME);
+
         // Verify memory stats do not increase after ingesting documents
         long[] currentSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
         long[] currentCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseMemoryStatsIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseMemoryStatsIT.java
@@ -5,6 +5,7 @@
 package org.opensearch.neuralsearch.sparse;
 
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.junit.After;
@@ -14,10 +15,8 @@ import org.opensearch.client.Response;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.neuralsearch.settings.NeuralSearchSettings;
 import org.opensearch.neuralsearch.sparse.cache.CacheKey;
-import org.opensearch.neuralsearch.stats.metrics.MetricStatName;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,8 +31,7 @@ public class SparseMemoryStatsIT extends SparseBaseIT {
     private static final String TEST_INDEX_NAME = "test-sparse-memory-stats";
     private static final String TEST_TEXT_FIELD_NAME = "text";
     private static final String TEST_SPARSE_FIELD_NAME = "sparse_field";
-    private static final String SPARSE_MEMORY_USAGE_METRIC_NAME = MetricStatName.MEMORY_SPARSE_MEMORY_USAGE.getNameString();
-    private static final String SPARSE_MEMORY_USAGE_METRIC_PATH = MetricStatName.MEMORY_SPARSE_MEMORY_USAGE.getFullPath();
+    private static final double DELTA_FOR_MEMORY_STATS_ASSERTION = 0.01d;
 
     /**
      * Enable neural stats
@@ -72,9 +70,9 @@ public class SparseMemoryStatsIT extends SparseBaseIT {
         assertTrue(indexExists(TEST_INDEX_NAME));
 
         // Fetch original memory stats
-        long[] originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long[] originalCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
-        assertArrayEquals(originalSparseMemoryUsageStats, originalCircuitBreakerMemoryStats);
+        List<Double> originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        List<Long> originalCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
+        verityMemoryStatsAlign(originalSparseMemoryUsageStats, originalCircuitBreakerMemoryStats);
 
         // Ingest documents
         List<Map<String, Float>> docs = new ArrayList<>();
@@ -91,27 +89,27 @@ public class SparseMemoryStatsIT extends SparseBaseIT {
         ingestDocumentsAndForceMerge(TEST_INDEX_NAME, TEST_TEXT_FIELD_NAME, TEST_SPARSE_FIELD_NAME, docs);
 
         // Verify memory stats increase after ingesting documents
-        long[] currentSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long[] currentCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
+        List<Double> currentSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        List<Long> currentCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
 
-        long originalSparseMemoryUsageSum = Arrays.stream(originalSparseMemoryUsageStats).sum();
-        long originalCircuitBreakerMemoryStatsSum = Arrays.stream(originalCircuitBreakerMemoryStats).sum();
-        long currentSparseMemoryUsageSum = Arrays.stream(currentSparseMemoryUsageStats).sum();
-        long currentCircuitBreakerMemoryStatsSum = Arrays.stream(currentCircuitBreakerMemoryStats).sum();
+        double originalSparseMemoryUsageSum = originalSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
+        long originalCircuitBreakerMemoryStatsSum = originalCircuitBreakerMemoryStats.stream().mapToLong(Long::longValue).sum();
+        double currentSparseMemoryUsageSum = currentSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
+        long currentCircuitBreakerMemoryStatsSum = currentCircuitBreakerMemoryStats.stream().mapToLong(Long::longValue).sum();
 
         assertTrue(currentSparseMemoryUsageSum > originalSparseMemoryUsageSum);
         assertTrue(currentCircuitBreakerMemoryStatsSum > originalCircuitBreakerMemoryStatsSum);
-        assertArrayEquals(currentSparseMemoryUsageStats, currentCircuitBreakerMemoryStats);
+        verityMemoryStatsAlign(currentSparseMemoryUsageStats, currentCircuitBreakerMemoryStats);
 
         // Verify memory stats are the same as the original after index deletion
         deleteIndex(TEST_INDEX_NAME);
         currentSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
         currentCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
-        currentSparseMemoryUsageSum = Arrays.stream(currentSparseMemoryUsageStats).sum();
-        currentCircuitBreakerMemoryStatsSum = Arrays.stream(currentCircuitBreakerMemoryStats).sum();
-        assertEquals(originalSparseMemoryUsageSum, currentSparseMemoryUsageSum);
+        currentSparseMemoryUsageSum = currentSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
+        currentCircuitBreakerMemoryStatsSum = currentCircuitBreakerMemoryStats.stream().mapToLong(Long::longValue).sum();
+        assertEquals(originalSparseMemoryUsageSum, currentSparseMemoryUsageSum, DELTA_FOR_MEMORY_STATS_ASSERTION);
         assertEquals(originalCircuitBreakerMemoryStatsSum, currentCircuitBreakerMemoryStatsSum);
-        assertArrayEquals(currentSparseMemoryUsageStats, currentCircuitBreakerMemoryStats);
+        verityMemoryStatsAlign(currentSparseMemoryUsageStats, currentCircuitBreakerMemoryStats);
     }
 
     /**
@@ -120,35 +118,35 @@ public class SparseMemoryStatsIT extends SparseBaseIT {
     @SneakyThrows
     public void testMemoryStatsIncreaseWithSeismicAndMultiShard() {
         // Fetch original memory stats
-        long[] originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long[] originalCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
-        assertArrayEquals(originalSparseMemoryUsageStats, originalCircuitBreakerMemoryStats);
+        List<Double> originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        List<Long> originalCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
+        verityMemoryStatsAlign(originalSparseMemoryUsageStats, originalCircuitBreakerMemoryStats);
 
         // Create Sparse Index
         prepareMultiShardReplicasIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, TEST_TEXT_FIELD_NAME);
 
         // Verify memory stats increase after ingesting documents
-        long[] currentSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long[] currentCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
+        List<Double> currentSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        List<Long> currentCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
 
-        long originalSparseMemoryUsageSum = Arrays.stream(originalSparseMemoryUsageStats).sum();
-        long originalCircuitBreakerMemoryStatsSum = Arrays.stream(originalCircuitBreakerMemoryStats).sum();
-        long currentSparseMemoryUsageSum = Arrays.stream(currentSparseMemoryUsageStats).sum();
-        long currentCircuitBreakerMemoryStatsSum = Arrays.stream(currentCircuitBreakerMemoryStats).sum();
+        double originalSparseMemoryUsageSum = originalSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
+        long originalCircuitBreakerMemoryStatsSum = originalCircuitBreakerMemoryStats.stream().mapToLong(Long::longValue).sum();
+        double currentSparseMemoryUsageSum = currentSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
+        long currentCircuitBreakerMemoryStatsSum = currentCircuitBreakerMemoryStats.stream().mapToLong(Long::longValue).sum();
 
         assertTrue(currentSparseMemoryUsageSum > originalSparseMemoryUsageSum);
         assertTrue(currentCircuitBreakerMemoryStatsSum > originalCircuitBreakerMemoryStatsSum);
-        assertArrayEquals(currentSparseMemoryUsageStats, currentCircuitBreakerMemoryStats);
+        verityMemoryStatsAlign(currentSparseMemoryUsageStats, currentCircuitBreakerMemoryStats);
 
         // Verify memory stats are the same as the original after index deletion
         deleteIndex(TEST_INDEX_NAME);
         currentSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
         currentCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
-        currentSparseMemoryUsageSum = Arrays.stream(currentSparseMemoryUsageStats).sum();
-        currentCircuitBreakerMemoryStatsSum = Arrays.stream(currentCircuitBreakerMemoryStats).sum();
-        assertEquals(originalSparseMemoryUsageSum, currentSparseMemoryUsageSum);
+        currentSparseMemoryUsageSum = currentSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
+        currentCircuitBreakerMemoryStatsSum = currentCircuitBreakerMemoryStats.stream().mapToLong(Long::longValue).sum();
+        assertEquals(originalSparseMemoryUsageSum, currentSparseMemoryUsageSum, DELTA_FOR_MEMORY_STATS_ASSERTION);
         assertEquals(originalCircuitBreakerMemoryStatsSum, currentCircuitBreakerMemoryStatsSum);
-        assertArrayEquals(currentSparseMemoryUsageStats, currentCircuitBreakerMemoryStats);
+        verityMemoryStatsAlign(currentSparseMemoryUsageStats, currentCircuitBreakerMemoryStats);
     }
 
     /**
@@ -157,34 +155,34 @@ public class SparseMemoryStatsIT extends SparseBaseIT {
     @SneakyThrows
     public void testMemoryStatsDoNotIncreaseWithAllRankFeatures() {
         // Fetch original memory stats
-        long[] originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long[] originalCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
-        assertArrayEquals(originalSparseMemoryUsageStats, originalCircuitBreakerMemoryStats);
+        List<Double> originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        List<Long> originalCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
+        verityMemoryStatsAlign(originalSparseMemoryUsageStats, originalCircuitBreakerMemoryStats);
 
         prepareOnlyRankFeaturesIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, TEST_TEXT_FIELD_NAME);
 
         // Verify memory stats do not increase after ingesting documents
-        long[] currentSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long[] currentCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
+        List<Double> currentSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        List<Long> currentCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
 
-        long originalSparseMemoryUsageSum = Arrays.stream(originalSparseMemoryUsageStats).sum();
-        long originalCircuitBreakerMemoryStatsSum = Arrays.stream(originalCircuitBreakerMemoryStats).sum();
-        long currentSparseMemoryUsageSum = Arrays.stream(currentSparseMemoryUsageStats).sum();
-        long currentCircuitBreakerMemoryStatsSum = Arrays.stream(currentCircuitBreakerMemoryStats).sum();
+        double originalSparseMemoryUsageSum = originalSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
+        long originalCircuitBreakerMemoryStatsSum = originalCircuitBreakerMemoryStats.stream().mapToLong(Long::longValue).sum();
+        double currentSparseMemoryUsageSum = currentSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
+        long currentCircuitBreakerMemoryStatsSum = currentCircuitBreakerMemoryStats.stream().mapToLong(Long::longValue).sum();
 
-        assertEquals(currentSparseMemoryUsageSum, originalSparseMemoryUsageSum);
+        assertEquals(currentSparseMemoryUsageSum, originalSparseMemoryUsageSum, DELTA_FOR_MEMORY_STATS_ASSERTION);
         assertEquals(currentCircuitBreakerMemoryStatsSum, originalCircuitBreakerMemoryStatsSum);
-        assertArrayEquals(currentSparseMemoryUsageStats, currentCircuitBreakerMemoryStats);
+        verityMemoryStatsAlign(currentSparseMemoryUsageStats, currentCircuitBreakerMemoryStats);
 
         // Verify memory stats are the same as the original after index deletion
         deleteIndex(TEST_INDEX_NAME);
         currentSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
         currentCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
-        currentSparseMemoryUsageSum = Arrays.stream(currentSparseMemoryUsageStats).sum();
-        currentCircuitBreakerMemoryStatsSum = Arrays.stream(currentCircuitBreakerMemoryStats).sum();
-        assertEquals(originalSparseMemoryUsageSum, currentSparseMemoryUsageSum);
+        currentSparseMemoryUsageSum = currentSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
+        currentCircuitBreakerMemoryStatsSum = currentCircuitBreakerMemoryStats.stream().mapToLong(Long::longValue).sum();
+        assertEquals(originalSparseMemoryUsageSum, currentSparseMemoryUsageSum, DELTA_FOR_MEMORY_STATS_ASSERTION);
         assertEquals(originalCircuitBreakerMemoryStatsSum, currentCircuitBreakerMemoryStatsSum);
-        assertArrayEquals(currentSparseMemoryUsageStats, currentCircuitBreakerMemoryStats);
+        verityMemoryStatsAlign(currentSparseMemoryUsageStats, currentCircuitBreakerMemoryStats);
     }
 
     /**
@@ -203,9 +201,9 @@ public class SparseMemoryStatsIT extends SparseBaseIT {
         assertTrue(indexExists(TEST_INDEX_NAME));
 
         // Fetch original memory stats
-        long[] originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long[] originalCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
-        assertArrayEquals(originalSparseMemoryUsageStats, originalCircuitBreakerMemoryStats);
+        List<Double> originalSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        List<Long> originalCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
+        verityMemoryStatsAlign(originalSparseMemoryUsageStats, originalCircuitBreakerMemoryStats);
 
         // Ingest documents
         List<Map<String, Float>> docs = new ArrayList<>();
@@ -222,13 +220,13 @@ public class SparseMemoryStatsIT extends SparseBaseIT {
         ingestDocumentsAndForceMerge(TEST_INDEX_NAME, TEST_TEXT_FIELD_NAME, TEST_SPARSE_FIELD_NAME, docs);
 
         // Verify memory stats only increase by cache registry size
-        long[] currentSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
-        long[] currentCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
+        List<Double> currentSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
+        List<Long> currentCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
 
-        long originalSparseMemoryUsageSum = Arrays.stream(originalSparseMemoryUsageStats).sum();
-        long originalCircuitBreakerMemoryStatsSum = Arrays.stream(originalCircuitBreakerMemoryStats).sum();
-        long currentSparseMemoryUsageSum = Arrays.stream(currentSparseMemoryUsageStats).sum();
-        long currentCircuitBreakerMemoryStatsSum = Arrays.stream(currentCircuitBreakerMemoryStats).sum();
+        double originalSparseMemoryUsageSum = originalSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
+        long originalCircuitBreakerMemoryStatsSum = originalCircuitBreakerMemoryStats.stream().mapToLong(Long::longValue).sum();
+        double currentSparseMemoryUsageSum = currentSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
+        long currentCircuitBreakerMemoryStatsSum = currentCircuitBreakerMemoryStats.stream().mapToLong(Long::longValue).sum();
 
         // Cache registry size consists of two cache keys, one array for forward index and one map for clustered posting
         CacheKey cacheKey = new CacheKey(TestsPrepareUtils.prepareSegmentInfo(), TestsPrepareUtils.prepareKeyFieldInfo());
@@ -236,25 +234,29 @@ public class SparseMemoryStatsIT extends SparseBaseIT {
         long emptyForwardIndexSize = RamUsageEstimator.shallowSizeOf(new AtomicReferenceArray<>(docCount));
         long emptyClusteredPostingSize = RamUsageEstimator.shallowSizeOf(new ConcurrentHashMap<>());
 
-        long registrySize = cacheKeySize * 2 + emptyClusteredPostingSize + emptyForwardIndexSize;
+        double registrySize = (cacheKeySize * 2 + emptyClusteredPostingSize + emptyForwardIndexSize) / 1024.0d;
 
-        assertEquals(registrySize, currentSparseMemoryUsageSum - originalSparseMemoryUsageSum);
-        assertEquals(registrySize, currentCircuitBreakerMemoryStatsSum - originalCircuitBreakerMemoryStatsSum);
-        assertArrayEquals(currentSparseMemoryUsageStats, currentCircuitBreakerMemoryStats);
+        assertEquals(registrySize, currentSparseMemoryUsageSum - originalSparseMemoryUsageSum, DELTA_FOR_MEMORY_STATS_ASSERTION);
+        assertEquals(
+            registrySize,
+            currentCircuitBreakerMemoryStatsSum - originalCircuitBreakerMemoryStatsSum,
+            DELTA_FOR_MEMORY_STATS_ASSERTION
+        );
+        verityMemoryStatsAlign(currentSparseMemoryUsageStats, currentCircuitBreakerMemoryStats);
 
         // Verify memory stats are the same as the original after index deletion
         deleteIndex(TEST_INDEX_NAME);
         currentSparseMemoryUsageStats = getSparseMemoryUsageStatsAcrossNodes();
         currentCircuitBreakerMemoryStats = getNeuralCircuitBreakerMemoryStatsAcrossNodes();
-        currentSparseMemoryUsageSum = Arrays.stream(currentSparseMemoryUsageStats).sum();
-        currentCircuitBreakerMemoryStatsSum = Arrays.stream(currentCircuitBreakerMemoryStats).sum();
-        assertEquals(originalSparseMemoryUsageSum, currentSparseMemoryUsageSum);
+        currentSparseMemoryUsageSum = currentSparseMemoryUsageStats.stream().mapToDouble(Double::doubleValue).sum();
+        currentCircuitBreakerMemoryStatsSum = currentCircuitBreakerMemoryStats.stream().mapToLong(Long::longValue).sum();
+        assertEquals(originalSparseMemoryUsageSum, currentSparseMemoryUsageSum, DELTA_FOR_MEMORY_STATS_ASSERTION);
         assertEquals(originalCircuitBreakerMemoryStatsSum, currentCircuitBreakerMemoryStatsSum);
-        assertArrayEquals(currentSparseMemoryUsageStats, currentCircuitBreakerMemoryStats);
+        verityMemoryStatsAlign(currentSparseMemoryUsageStats, currentCircuitBreakerMemoryStats);
     }
 
     @SneakyThrows
-    private long[] getNeuralCircuitBreakerMemoryStatsAcrossNodes() {
+    private List<Long> getNeuralCircuitBreakerMemoryStatsAcrossNodes() {
         Request request = new Request("GET", "_nodes/stats/breaker/");
 
         Response response = client().performRequest(request);
@@ -265,10 +267,17 @@ public class SparseMemoryStatsIT extends SparseBaseIT {
 
         List<Long> circuitBreakerStats = new ArrayList<>();
         for (Map<String, Object> nodeStatsResponse : nodeStatsResponseList) {
-            // we do not use breakers.neural_search.estimated_size_in_bytes due to precision limitation by memory stats
-            String stringValue = getNestedValue(nodeStatsResponse, "breakers.neural_search.estimated_size").toString();
-            circuitBreakerStats.add(parseFractionalSize(stringValue));
+            String stringValue = getNestedValue(nodeStatsResponse, "breakers.neural_search.estimated_size_in_bytes").toString();
+            circuitBreakerStats.add(NumberUtils.createLong(stringValue));
         }
-        return circuitBreakerStats.stream().mapToLong(Long::longValue).toArray();
+        return circuitBreakerStats;
+    }
+
+    private void verityMemoryStatsAlign(List<Double> memoryUsageStats, List<Long> circuitBreakerStats) {
+        assertEquals(memoryUsageStats.size(), circuitBreakerStats.size());
+        for (int i = 0; i < memoryUsageStats.size(); ++i) {
+            double circuitBreakerKbSize = circuitBreakerStats.get(i) / 1024.0d;
+            assertEquals(memoryUsageStats.get(i), circuitBreakerKbSize, DELTA_FOR_MEMORY_STATS_ASSERTION);
+        }
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/TestsPrepareUtils.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/TestsPrepareUtils.java
@@ -65,10 +65,6 @@ import static org.apache.lucene.tests.util.LuceneTestCase.random;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.FilterLeafReader;
-import org.apache.lucene.index.FilterDirectoryReader;
-
 public class TestsPrepareUtils {
 
     private final static String fieldName = "test_field";

--- a/src/test/java/org/opensearch/neuralsearch/sparse/cache/ForwardIndexCacheTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/cache/ForwardIndexCacheTests.java
@@ -27,7 +27,6 @@ public class ForwardIndexCacheTests extends AbstractSparseTestBase {
     private long emptyForwardIndexCacheSize;
     private long emptyForwardIndexCacheItemSize;
     private ForwardIndexCache forwardIndexCache;
-    private RamBytesRecorder mockGlobalRecorder;
 
     /**
      * Set up the test environment before each test.

--- a/src/test/resources/sparse-tests/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/sparse-tests/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,2 +1,0 @@
-mock-maker-inline
-


### PR DESCRIPTION
### Description
This PR adjusts IT according to memory stats change. Now the sparse related IT should all pass:

```
./gradlew integTest --tests "org.opensearch.neuralsearch.sparse.*"

./gradlew integTest --tests "org.opensearch.neuralsearch.sparse.*" -PnumNodes=3
```

This PR also contains a few cleanup commits to remove unused code changes. Some additional test cases will be added later.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
